### PR TITLE
Correct installation instructions in README.md e removal of aliases in the command description

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/README.md
+++ b/README.md
@@ -56,12 +56,28 @@ Welcome to BuildCLI - Java Project Management!
    mvn package
    ```
 
-   3. **Set up BuildCLI for Global Access**:
-       - Copy the `buildcli` file to a directory in your system PATH, such as `~/bin`:
-         ```bash
-         cp target/BuildCLI-1.0-SNAPSHOT.jar ~/bin/buildcli
-         chmod +x ~/bin/buildcli
-         ```
+3. **Set up BuildCLI for Global Access**:
+- Copy the `buildcli` file to a directory in your system PATH, such as `~/bin`:
+   ```bash
+   cp target/BuildCLI-1.0-SNAPSHOT.jar ~/bin/
+  ```
+- Create a wrapper script:
+  ```bash 
+   nano ~/bin/buildcli
+   ```
+- Insert the following content into the file:
+   ```bash
+  #!/bin/bash
+   java -jar "$HOME/bin/BuildCLI-1.0-SNAPSHOT.jar" "$@"
+   ```
+- Save and exit Nano:
+  - Press CTRL + O, then Enter to save.
+  - Press CTRL + X to exit.
+  
+- Make the script executable:
+     ```bash
+     chmod +x ~/bin/buildcli
+     ```
 
 Now `BuildCLI` is ready to use. Test the `buildcli` command in the terminal.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Welcome to BuildCLI - Java Project Management!
 3. **Set up BuildCLI for Global Access**:
 - Copy the `buildcli` file to a directory in your system PATH, such as `~/bin`:
    ```bash
-   cp target/BuildCLI-1.0-SNAPSHOT.jar ~/bin/
+   cp target/buildcli.jar ~/bin/
   ```
 - Create a wrapper script:
   ```bash 
@@ -68,7 +68,7 @@ Welcome to BuildCLI - Java Project Management!
 - Insert the following content into the file:
    ```bash
   #!/bin/bash
-   java -jar "$HOME/bin/BuildCLI-1.0-SNAPSHOT.jar" "$@"
+   java -jar "$HOME/bin/buildcli.jar.jar" "$@"
    ```
 - Save and exit Nano:
   - Press CTRL + O, then Enter to save.

--- a/src/main/java/org/buildcli/commands/ProjectCommand.java
+++ b/src/main/java/org/buildcli/commands/ProjectCommand.java
@@ -3,7 +3,7 @@ package org.buildcli.commands;
 import org.buildcli.commands.project.*;
 import picocli.CommandLine.Command;
 
-@Command(name = "project", aliases = {"p"}, description = "Manage and create Java projects, alias: 'p'.",
+@Command(name = "project", aliases = {"p"}, description = "Manage and create Java projects.",
     subcommands = {
         AddCommand.class, RmCommand.class, BuildCommand.class, SetCommand.class,
         TestCommand.class, RunCommand.class, InitCommand.class, CleanupCommand.class,

--- a/src/main/java/org/buildcli/commands/project/AddCommand.java
+++ b/src/main/java/org/buildcli/commands/project/AddCommand.java
@@ -6,7 +6,7 @@ import org.buildcli.commands.project.add.PipelineCommand;
 import org.buildcli.commands.project.add.ProfileCommand;
 import picocli.CommandLine.Command;
 
-@Command(name = "add", aliases = {"a"}, description = "Adds a new item to the project. Alias: 'a'. This command "
+@Command(name = "add", aliases = {"a"}, description = "Adds a new item to the project. This command "
         + "allows adding dependencies, pipelines, profiles, and Dockerfiles.",
         subcommands = {DependencyCommand.class, PipelineCommand.class, ProfileCommand.class, DockerfileCommand.class},
         mixinStandardHelpOptions = true

--- a/src/main/java/org/buildcli/commands/project/BuildCommand.java
+++ b/src/main/java/org/buildcli/commands/project/BuildCommand.java
@@ -7,7 +7,7 @@ import picocli.CommandLine.Option;
 
 import java.util.logging.Logger;
 
-@Command(name = "build", aliases = {"b"}, description = "Builds the project, either compiling or packaging, and logs the result, alias: 'b'.", mixinStandardHelpOptions = true)
+@Command(name = "build", aliases = {"b"}, description = "Builds the project, either compiling or packaging, and logs the result.", mixinStandardHelpOptions = true)
 public class BuildCommand implements BuildCLICommand {
   private final Logger logger = Logger.getLogger(BuildCommand.class.getName());
 

--- a/src/main/java/org/buildcli/commands/project/CleanupCommand.java
+++ b/src/main/java/org/buildcli/commands/project/CleanupCommand.java
@@ -5,7 +5,7 @@ import org.buildcli.domain.BuildCLICommand;
 import org.buildcli.utils.DirectoryCleanup;
 import picocli.CommandLine.Command;
 
-@Command(name = "cleanup", aliases = {"clean"}, description = "Removes generated files by cleaning the project's target directory, alias: 'clean'.", mixinStandardHelpOptions = true)
+@Command(name = "cleanup", aliases = {"clean"}, description = "Removes generated files by cleaning the project's target directory.", mixinStandardHelpOptions = true)
 public class CleanupCommand implements BuildCLICommand {
   @Override
   public void run() {

--- a/src/main/java/org/buildcli/commands/project/DocumentCodeCommand.java
+++ b/src/main/java/org/buildcli/commands/project/DocumentCodeCommand.java
@@ -14,7 +14,7 @@ import picocli.CommandLine.Parameters;
 @Command(
     name = "document-code",
     aliases = {"docs"},
-    description = "Generates documentation for the project code. Alias: 'docs'. This command scans the specified files and extracts structured documentation.",
+    description = "Generates documentation for the project code. This command scans the specified files and extracts structured documentation.",
     mixinStandardHelpOptions = true
 )
 public class DocumentCodeCommand implements BuildCLICommand {

--- a/src/main/java/org/buildcli/commands/project/InitCommand.java
+++ b/src/main/java/org/buildcli/commands/project/InitCommand.java
@@ -15,7 +15,7 @@ import picocli.CommandLine.Option;
 @Command(
     name = "init",
     aliases = {"i"},
-    description = "Initializes a new project. Alias: 'i'. This command sets up a new project structure.",
+    description = "Initializes a new project. This command sets up a new project structure.",
     mixinStandardHelpOptions = true
 )
 public class InitCommand implements BuildCLICommand {

--- a/src/main/java/org/buildcli/commands/project/RmCommand.java
+++ b/src/main/java/org/buildcli/commands/project/RmCommand.java
@@ -4,7 +4,7 @@ import org.buildcli.commands.project.rm.DependencyCommand;
 import org.buildcli.commands.project.rm.ProfileCommand;
 import picocli.CommandLine.Command;
 
-@Command(name = "remove", aliases = {"rm"}, description = "Removes dependencies and profiles from the project, alias: 'rm'.",
+@Command(name = "remove", aliases = {"rm"}, description = "Removes dependencies and profiles from the project.",
     subcommands = {DependencyCommand.class, ProfileCommand.class},
     mixinStandardHelpOptions = true
 )

--- a/src/main/java/org/buildcli/commands/project/TestCommand.java
+++ b/src/main/java/org/buildcli/commands/project/TestCommand.java
@@ -4,7 +4,7 @@ import org.buildcli.core.ProjectTester;
 import org.buildcli.domain.BuildCLICommand;
 import picocli.CommandLine.Command;
 
-@Command(name = "test", aliases = {"t"}, description = "Executes the project tests, alias: 't'.", mixinStandardHelpOptions = true)
+@Command(name = "test", aliases = {"t"}, description = "Executes the project tests.", mixinStandardHelpOptions = true)
 public class TestCommand implements BuildCLICommand {
   @Override
   public void run() {

--- a/src/main/java/org/buildcli/commands/project/UpdateCommand.java
+++ b/src/main/java/org/buildcli/commands/project/UpdateCommand.java
@@ -4,7 +4,7 @@ import org.buildcli.commands.project.update.DependencyCommand;
 import org.buildcli.commands.project.update.VersionCommand;
 import picocli.CommandLine.Command;
 
-@Command(name = "update", aliases = {"up"}, description = "Updates project versions and dependencies, alias: 'up'.", mixinStandardHelpOptions = true,
+@Command(name = "update", aliases = {"up"}, description = "Updates project versions and dependencies.", mixinStandardHelpOptions = true,
     subcommands = {VersionCommand.class, DependencyCommand.class}
 )
 public class UpdateCommand {


### PR DESCRIPTION
I made a few changes because the guide was still incorrect. With these updates, new users will have a better first impression. ☕

I removed some aliases in the command descriptions to avoid redundant information.