### PR TITLE
Create a Multiplatform Installation Script - Issue 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Welcome to BuildCLI - Java Project Management!
 
 1. **Clone the Repository**:
    ```bash
-   git clone https://github.com/wheslleyrimar/buildcli.git
-   cd buildcli
+   git clone https://github.com/BuildCLI/BuildCLI.git
+   cd BuildCLI
    ```
 
 2. **Build and Package the Project**:
@@ -57,11 +57,15 @@ Welcome to BuildCLI - Java Project Management!
    ```
 
    3. **Set up BuildCLI for Global Access**:
-       - Copy the `buildcli` file to a directory in your system PATH, such as `~/bin`:
-         ```bash
-         cp target/BuildCLI-1.0-SNAPSHOT.jar ~/bin/buildcli
-         chmod +x ~/bin/buildcli
-         ```
+     - On a Unix-like system (Linux, macOS), simply give execution permission to `install.sh` and run it:  
+     ```bash
+     sudo chmod +x install.sh  
+     ./install.sh  
+     ```
+     - On Windows: Run `install.bat` by double-clicking it or executing the following command in the Command Prompt (cmd):  
+     ```cmd
+     install.bat
+     ```
 
 Now `BuildCLI` is ready to use. Test the `buildcli` command in the terminal.
 

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,67 @@
+@echo off
+setlocal
+
+echo Cloning the BuildCLI repository...
+git clone https://github.com/wheslleyrimar/buildcli.git || (
+    echo Failed to clone repository. Make sure Git is installed.
+    pause
+    exit /b 1
+)
+
+cd buildcli || (
+    echo Directory 'buildcli' not found. Cloning may have failed.
+    pause
+    exit /b 1
+)
+
+echo Checking if Maven is installed...
+where mvn >nul 2>nul
+if %errorlevel% neq 0 (
+    echo Maven not found. Please install Maven.
+    pause
+    exit /b 1
+)
+
+echo Checking if Java is installed...
+where java >nul 2>nul
+if %errorlevel% neq 0 (
+    echo Java not found. Please install Java.
+    pause
+    exit /b 1
+)
+
+echo Building and packaging the project...
+mvn clean package || (
+    echo Maven build failed.
+    pause
+    exit /b 1
+)
+
+echo Configuring BuildCLI for global access...
+
+if not exist %USERPROFILE%\bin (
+    echo Creating directory %USERPROFILE%\bin...
+    mkdir %USERPROFILE%\bin
+)
+
+echo Copying BuildCLI JAR to %USERPROFILE%\bin...
+copy target\buildcli.jar %USERPROFILE%\bin\buildcli.jar
+
+echo Creating buildcli.bat shortcut...
+(
+    echo @echo off
+    echo java -jar "%%USERPROFILE%%\bin\buildcli.jar" %%*
+) > %USERPROFILE%\bin\buildcli.bat
+
+echo Ensuring %USERPROFILE%\bin is in the PATH...
+echo If the command fails, add this manually to your environment variables:
+echo.
+echo setx PATH "%%USERPROFILE%%\bin;%%PATH%%"
+echo.
+
+echo Installation completed!
+echo You can now run BuildCLI using:
+echo buildcli
+pause
+endlocal
+

--- a/install.bat
+++ b/install.bat
@@ -2,14 +2,14 @@
 setlocal
 
 echo Cloning the BuildCLI repository...
-git clone https://github.com/wheslleyrimar/buildcli.git || (
+git clone https://github.com/BuildCLI/BuildCLI.git || (
     echo Failed to clone repository. Make sure Git is installed.
     pause
     exit /b 1
 )
 
-cd buildcli || (
-    echo Directory 'buildcli' not found. Cloning may have failed.
+cd BuildCLI || (
+    echo Directory 'BuildCLI' not found. Cloning may have failed.
     pause
     exit /b 1
 )
@@ -56,7 +56,7 @@ echo Creating buildcli.bat shortcut...
 echo Ensuring %USERPROFILE%\bin is in the PATH...
 echo If the command fails, add this manually to your environment variables:
 echo.
-echo setx PATH "%%USERPROFILE%%\bin;%%PATH%%"
+echo setx PATH "%PATH%;%USERPROFILE%\bin"
 echo.
 
 echo Installation completed!

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e 
+
+function check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        echo "$1 is not installed, please install it before proceeding."
+        exit 1
+    fi
+}
+
+check_command java
+check_command mvn
+
+if ! git clone https://github.com/wheslleyrimar/buildcli.git ; then 
+	echo "Failed to clone repository. Make sure Git is installed."
+	exit 1
+fi
+cd buildcli
+
+if ! mvn clean package; then
+    echo "Error while creating Maven package."
+    exit 1
+fi
+
+if [ ! -d "$HOME/bin" ]; then
+    mkdir -p "$HOME/bin"
+fi
+
+cp target/buildcli.jar "$HOME/bin/"
+
+cat <<EOF > "$HOME/bin/buildcli"
+#!/bin/bash
+java -jar "\$HOME/bin/buildcli.jar" "\$@"
+EOF
+
+chmod +x "$HOME/bin/buildcli"
+
+if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+    echo "The directory \$HOME/bin is not in the PATH."
+    echo "Please add the following line to your ~/.bashrc, ~/.zshrc, or the appropriate shell configuration file:"
+    echo ""
+    echo 'export PATH="$HOME/bin:$PATH"'
+    echo ""
+    echo "Then, reload your shell with:"
+    echo "source ~/.bashrc  # or source ~/.zshrc if you use Zsh"
+    echo ""
+    echo "After that, you can run the application with: buildcli"
+else 
+    echo "You can now run the application with: buildcli"
+fi
+

--- a/install.sh
+++ b/install.sh
@@ -12,11 +12,11 @@ function check_command() {
 check_command java
 check_command mvn
 
-if ! git clone https://github.com/wheslleyrimar/buildcli.git ; then 
+if ! git clone https://github.com/BuildCLI/BuildCLI.git ; then 
 	echo "Failed to clone repository. Make sure Git is installed."
 	exit 1
 fi
-cd buildcli
+cd BuildCLI
 
 if ! mvn clean package; then
     echo "Error while creating Maven package."


### PR DESCRIPTION
The script automates the installation of BuildCLI by cloning the repository, verifying dependencies (Java and Maven), building the project, and configuring it for global access. On Unix-like systems, it also creates a script that allows running the project using the buildcli command.