### PR TITLE
fix(install): check if repo exists before cloning, pull if it does (bash & bat)

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,11 +1,22 @@
 @echo off
 setlocal
 
-echo Cloning the BuildCLI repository...
-git clone https://github.com/BuildCLI/BuildCLI.git || (
-    echo Failed to clone repository. Make sure Git is installed.
-    pause
-    exit /b 1
+if exist "BuildCLI\.git" (
+    echo Project directory already exists. Pulling latest changes...
+    cd BuildCLI
+    git pull origin main || (
+        echo Failed to update repository.
+        pause
+        exit /b 1
+    )
+    cd ..
+) else (
+    echo Cloning the BuildCLI repository...
+    git clone https://github.com/BuildCLI/BuildCLI.git || (
+        echo Failed to clone repository. Make sure Git is installed.
+        pause
+        exit /b 1
+    )
 )
 
 cd BuildCLI || (
@@ -39,24 +50,24 @@ mvn clean package || (
 
 echo Configuring BuildCLI for global access...
 
-if not exist %USERPROFILE%\bin (
+if not exist "%USERPROFILE%\bin" (
     echo Creating directory %USERPROFILE%\bin...
-    mkdir %USERPROFILE%\bin
+    mkdir "%USERPROFILE%\bin"
 )
 
 echo Copying BuildCLI JAR to %USERPROFILE%\bin...
-copy target\buildcli.jar %USERPROFILE%\bin\buildcli.jar
+copy target\buildcli.jar "%USERPROFILE%\bin\buildcli.jar" >nul
 
 echo Creating buildcli.bat shortcut...
 (
     echo @echo off
     echo java -jar "%%USERPROFILE%%\bin\buildcli.jar" %%*
-) > %USERPROFILE%\bin\buildcli.bat
+) > "%USERPROFILE%\bin\buildcli.bat"
 
 echo Ensuring %USERPROFILE%\bin is in the PATH...
 echo If the command fails, add this manually to your environment variables:
 echo.
-echo setx PATH "%PATH%;%USERPROFILE%\bin"
+echo setx PATH "%%PATH%%;%USERPROFILE%\bin"
 echo.
 
 echo Installation completed!
@@ -64,4 +75,3 @@ echo You can now run BuildCLI using:
 echo buildcli
 pause
 endlocal
-

--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,6 @@ EOF
 
 chmod +x "$HOME/bin/buildcli"
 
-# Adds $HOME/bin to PATH if necessary.
 if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
     echo "The directory \$HOME/bin is not in the PATH."
     echo "Please add the following line to your ~/.bashrc, ~/.zshrc, or the appropriate shell configuration file:"

--- a/install.sh
+++ b/install.sh
@@ -11,12 +11,20 @@ function check_command() {
 
 check_command java
 check_command mvn
+check_command git
 
-if ! git clone https://github.com/BuildCLI/BuildCLI.git ; then 
-	echo "Failed to clone repository. Make sure Git is installed."
-	exit 1
+if [ -d "BuildCLI/.git" ]; then
+    echo "Project directory already exists. Pulling latest changes..."
+    cd BuildCLI
+    git pull origin main || { echo "Failed to update repository."; exit 1; }
+else
+    echo "Cloning repository..."
+    if ! git clone https://github.com/BuildCLI/BuildCLI.git ; then 
+        echo "Failed to clone repository. Make sure Git is installed."
+        exit 1
+    fi
+    cd BuildCLI
 fi
-cd BuildCLI
 
 if ! mvn clean package; then
     echo "Error while creating Maven package."
@@ -36,6 +44,7 @@ EOF
 
 chmod +x "$HOME/bin/buildcli"
 
+# Adds $HOME/bin to PATH if necessary.
 if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
     echo "The directory \$HOME/bin is not in the PATH."
     echo "Please add the following line to your ~/.bashrc, ~/.zshrc, or the appropriate shell configuration file:"
@@ -49,4 +58,3 @@ if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
 else 
     echo "You can now run the application with: buildcli"
 fi
-


### PR DESCRIPTION
### Description
This pull request addresses issue #205 by modifying the installation scripts for Unix-like and Windows systems. 

The new behavior first checks if the repository directory exists:
- If **not present**, the script clones the repository as usual.
- If **already present**, the script performs a git pull to ensure the latest updates.

### Changes
- Updated **bash script** to check for the existing BuildCLI directory before cloning.
- If the directory exists, a git pull is executed instead.
- Applied the same logic to the **windows batch script**, ensuring consistency.

### Testing
- Ran the unix script:
  - Verified that the script skips cloning and pulls the latest changes when the directory exists.
  - Confirmed that it correctly clones when the directory is absent.
- Ran the Windows script with similar validations.

Let me know if any adjustments are needed! 

Fixes #205.