### PR TITLE
Fix: Update repository URL in about() method (#207)

### DIFF
--- a/src/main/java/org/buildcli/utils/BuildCLIIntro.java
+++ b/src/main/java/org/buildcli/utils/BuildCLIIntro.java
@@ -37,7 +37,8 @@ public class BuildCLIIntro {
 	public static void about() {
 		SystemOutLogger.log("BuildCLI is a command-line interface (CLI) tool for managing and automating common tasks in Java project development.\n" +
 				"It allows you to create, compile, manage dependencies, and run Java projects directly from the terminal, simplifying the development process.\n");
-		SystemOutLogger.log("Visit the repository for more details: https://github.com/wheslleyrimar/BuildCLI\n");
+		SystemOutLogger.log("Visit the repository for more details: https://github.com/BuildCLI/BuildCLI\n");
+
 
 		gitExec.showContributors(localRepository);
 	}


### PR DESCRIPTION
This PR updates the outdated repository URL in the `about()` method of `BuildCLIIntro.java` to point to the correct repository link: https://github.com/BuildCLI/BuildCLI.
