### PR TITLE
Fix/autocomplete bug after refactor

### DIFF
--- a/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
+++ b/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
@@ -2,8 +2,11 @@ package dev.buildcli.cli;
 
 import dev.buildcli.cli.commands.AboutCommand;
 import dev.buildcli.cli.commands.AutocompleteCommand;
+import dev.buildcli.cli.commands.ChangelogCommand;
 import dev.buildcli.cli.commands.ConfigCommand;
+import dev.buildcli.cli.commands.DoctorCommand;
 import dev.buildcli.cli.commands.ProjectCommand;
+import dev.buildcli.cli.commands.RunCommand;
 import dev.buildcli.cli.commands.VersionCommand;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -12,8 +15,8 @@ import picocli.CommandLine.Command;
     version = "BuildCLI 0.0.14",
     description = "BuildCLI - A CLI for Java Project Management",
     subcommands = {
-        AutocompleteCommand.class, ProjectCommand.class, VersionCommand.class,
-        AboutCommand.class, CommandLine.HelpCommand.class, ConfigCommand.class,
+        AboutCommand.class, AutocompleteCommand.class, ChangelogCommand.class, ConfigCommand.class,
+        DoctorCommand.class, ProjectCommand.class, RunCommand.class, VersionCommand.class, CommandLine.HelpCommand.class,
     }
 )
 public class BuildCLI {

--- a/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
+++ b/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
@@ -1,6 +1,6 @@
-package dev.buildcli.cli;
+package org.buildcli;
 
-import dev.buildcli.cli.commands.*;
+import org.buildcli.commands.*;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -8,9 +8,8 @@ import picocli.CommandLine.Command;
     version = "BuildCLI 0.0.14",
     description = "BuildCLI - A CLI for Java Project Management",
     subcommands = {
-        AutocompleteCommand.class, DoctorCommand.class, ProjectCommand.class, VersionCommand.class,
-        AboutCommand.class, CommandLine.HelpCommand.class, ConfigCommand.class,
-        RunCommand.class,ChangelogCommand.class
+        AutocompleteCommand.class, ProjectCommand.class, VersionCommand.class,
+        AboutCommand.class, CommandLine.HelpCommand.class, ConfigCommand.class
     }
 )
 public class BuildCLI {

--- a/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
+++ b/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
@@ -1,15 +1,35 @@
-package org.buildcli;
+package dev.buildcli.cli;
 
-import org.buildcli.commands.*;
+import dev.buildcli.cli.commands.AboutCommand;
+import dev.buildcli.cli.commands.AutocompleteCommand;
+import dev.buildcli.cli.commands.ChangelogCommand;
+import dev.buildcli.cli.commands.ConfigCommand;
+import dev.buildcli.cli.commands.DoctorCommand;
+import dev.buildcli.cli.commands.ProjectCommand;
+import dev.buildcli.cli.commands.RunCommand;
+import dev.buildcli.cli.commands.VersionCommand;
+import dev.buildcli.cli.commands.project.AddCommand;
+import dev.buildcli.cli.commands.project.BuildCommand;
+import dev.buildcli.cli.commands.project.CleanupCommand;
+import dev.buildcli.cli.commands.project.CodeCommand;
+import dev.buildcli.cli.commands.project.DocumentCodeCommand;
+import dev.buildcli.cli.commands.project.InitCommand;
+import dev.buildcli.cli.commands.project.ReleaseCommand;
+import dev.buildcli.cli.commands.project.RmCommand;
+import dev.buildcli.cli.commands.project.SetCommand;
+import dev.buildcli.cli.commands.project.TestCommand;
+import dev.buildcli.cli.commands.project.UpdateCommand;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "BuildCLI", mixinStandardHelpOptions = true,
+@Command(name = "buildcli", mixinStandardHelpOptions = true,
     version = "BuildCLI 0.0.14",
     description = "BuildCLI - A CLI for Java Project Management",
     subcommands = {
-        AutocompleteCommand.class, ProjectCommand.class, VersionCommand.class,
-        AboutCommand.class, CommandLine.HelpCommand.class, ConfigCommand.class
+        AddCommand.class, BuildCommand.class, CleanupCommand.class, CodeCommand.class, DocumentCodeCommand.class,
+        InitCommand.class, ReleaseCommand.class, RmCommand.class, SetCommand.class, TestCommand.class, UpdateCommand.class,
+        AboutCommand.class, AutocompleteCommand.class, ChangelogCommand.class, ConfigCommand.class,
+        DoctorCommand.class, ProjectCommand.class, RunCommand.class, VersionCommand.class, CommandLine.HelpCommand.class,
     }
 )
 public class BuildCLI {

--- a/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
+++ b/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
@@ -2,23 +2,9 @@ package dev.buildcli.cli;
 
 import dev.buildcli.cli.commands.AboutCommand;
 import dev.buildcli.cli.commands.AutocompleteCommand;
-import dev.buildcli.cli.commands.ChangelogCommand;
 import dev.buildcli.cli.commands.ConfigCommand;
-import dev.buildcli.cli.commands.DoctorCommand;
 import dev.buildcli.cli.commands.ProjectCommand;
-import dev.buildcli.cli.commands.RunCommand;
 import dev.buildcli.cli.commands.VersionCommand;
-import dev.buildcli.cli.commands.project.AddCommand;
-import dev.buildcli.cli.commands.project.BuildCommand;
-import dev.buildcli.cli.commands.project.CleanupCommand;
-import dev.buildcli.cli.commands.project.CodeCommand;
-import dev.buildcli.cli.commands.project.DocumentCodeCommand;
-import dev.buildcli.cli.commands.project.InitCommand;
-import dev.buildcli.cli.commands.project.ReleaseCommand;
-import dev.buildcli.cli.commands.project.RmCommand;
-import dev.buildcli.cli.commands.project.SetCommand;
-import dev.buildcli.cli.commands.project.TestCommand;
-import dev.buildcli.cli.commands.project.UpdateCommand;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -26,10 +12,8 @@ import picocli.CommandLine.Command;
     version = "BuildCLI 0.0.14",
     description = "BuildCLI - A CLI for Java Project Management",
     subcommands = {
-        AddCommand.class, BuildCommand.class, CleanupCommand.class, CodeCommand.class, DocumentCodeCommand.class,
-        InitCommand.class, ReleaseCommand.class, RmCommand.class, SetCommand.class, TestCommand.class, UpdateCommand.class,
-        AboutCommand.class, AutocompleteCommand.class, ChangelogCommand.class, ConfigCommand.class,
-        DoctorCommand.class, ProjectCommand.class, RunCommand.class, VersionCommand.class, CommandLine.HelpCommand.class,
+        AutocompleteCommand.class, ProjectCommand.class, VersionCommand.class,
+        AboutCommand.class, CommandLine.HelpCommand.class, ConfigCommand.class,
     }
 )
 public class BuildCLI {

--- a/cli/src/main/java/dev/buildcli/cli/commands/AboutCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/AboutCommand.java
@@ -5,7 +5,10 @@ import dev.buildcli.core.domain.BuildCLICommand;
 import dev.buildcli.core.utils.BuildCLIService;
 import picocli.CommandLine.Command;
 
-@Command(name = "about", aliases = {"ab"}, description = "Displays information about BuildCLI, including its purpose and usage.", mixinStandardHelpOptions = true)
+@Command(name = "about",
+        aliases = {"a"},
+        description = "Displays information about BuildCLI, including its purpose and usage.",
+        mixinStandardHelpOptions = true)
 public class AboutCommand implements BuildCLICommand {
 
   @Override

--- a/cli/src/main/java/dev/buildcli/cli/commands/AboutCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/AboutCommand.java
@@ -5,7 +5,7 @@ import dev.buildcli.core.domain.BuildCLICommand;
 import dev.buildcli.core.utils.BuildCLIService;
 import picocli.CommandLine.Command;
 
-@Command(name = "about", aliases = {"-a"}, description = "Displays information about BuildCLI, including its purpose and usage.", mixinStandardHelpOptions = true)
+@Command(name = "about", aliases = {"ab"}, description = "Displays information about BuildCLI, including its purpose and usage.", mixinStandardHelpOptions = true)
 public class AboutCommand implements BuildCLICommand {
 
   @Override

--- a/cli/src/main/java/dev/buildcli/cli/commands/AboutCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/AboutCommand.java
@@ -5,7 +5,7 @@ import dev.buildcli.core.domain.BuildCLICommand;
 import dev.buildcli.core.utils.BuildCLIService;
 import picocli.CommandLine.Command;
 
-@Command(name = "about", aliases = {"a"}, description = "Displays information about BuildCLI, including its purpose and usage.", mixinStandardHelpOptions = true)
+@Command(name = "about", aliases = {"-a"}, description = "Displays information about BuildCLI, including its purpose and usage.", mixinStandardHelpOptions = true)
 public class AboutCommand implements BuildCLICommand {
 
   @Override

--- a/cli/src/main/java/dev/buildcli/cli/commands/AutocompleteCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/AutocompleteCommand.java
@@ -4,7 +4,10 @@ import dev.buildcli.core.domain.BuildCLICommand;
 import dev.buildcli.core.utils.AutoCompleteManager;
 import picocli.CommandLine.Command;
 
-@Command(name = "autocomplete", description = "Sets up autocomplete for BuildCLI commands to enhance user experience by suggesting commands as you type.", mixinStandardHelpOptions = true)
+@Command(name = "autocomplete",
+        aliases = {"ac"},
+        description = "Sets up autocomplete for BuildCLI commands to enhance user experience by suggesting commands as you type.",
+        mixinStandardHelpOptions = true)
 public class AutocompleteCommand implements BuildCLICommand {
   @Override
   public void run() {

--- a/cli/src/main/java/dev/buildcli/cli/commands/ChangelogCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/ChangelogCommand.java
@@ -1,6 +1,6 @@
-package org.buildcli.commands;
+package dev.buildcli.cli.commands;
 
-import org.buildcli.domain.BuildCLICommand;
+import dev.buildcli.core.domain.BuildCLICommand;
 import org.buildcli.utils.FileTypes;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;

--- a/core/src/main/java/dev/buildcli/core/utils/AutoCompleteManager.java
+++ b/core/src/main/java/dev/buildcli/core/utils/AutoCompleteManager.java
@@ -2,7 +2,9 @@ package dev.buildcli.core.utils;
 
 import picocli.AutoComplete;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -15,7 +17,7 @@ public class AutoCompleteManager {
 
     public void setupAutocomplete() {
         String commandName = "buildcli";
-        String fullyQualifiedClassName = "org.buildcli.OptionCommand";
+        String fullyQualifiedClassName = "org.buildcli.BuildCLI";
 
         try {
             List<String> availableShells = detectAvailableShells();
@@ -51,14 +53,15 @@ public class AutoCompleteManager {
     }
 
     private boolean isShellInstalled(String shell) {
-        Path shellPath = switch (shell) {
-            case "bash" -> Path.of("/bin/bash");
-            case "zsh" -> Path.of("/bin/zsh");
-            case "fish" -> Path.of("/usr/bin/fish");
-            default -> null;
-        };
+        try{
+            Process process = new ProcessBuilder(OS.isWindows() ? "where" : "which", OS.isWindows() ? shell + ".exe" : shell).start();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+            String output = reader.readLine();
 
-        return shellPath != null && Files.exists(shellPath);
+            return output != null && !output.isBlank();
+        } catch (Exception e){
+            return false;
+        }
     }
 
     private void generateAutoComplete(String fullyQualifiedClassName, String commandName, Path completionPath) {

--- a/core/src/main/java/dev/buildcli/core/utils/AutoCompleteManager.java
+++ b/core/src/main/java/dev/buildcli/core/utils/AutoCompleteManager.java
@@ -17,7 +17,7 @@ public class AutoCompleteManager {
 
     public void setupAutocomplete() {
         String commandName = "buildcli";
-        String fullyQualifiedClassName = "org.buildcli.BuildCLI";
+        String fullyQualifiedClassName = "dev.buildcli.cli.BuildCLI";
 
         try {
             List<String> availableShells = detectAvailableShells();


### PR DESCRIPTION
This Pull Request addresses Issue #237, which reported that the autocomplete command in BuildCLI stopped functioning after a major refactor mentioned in Issue #70. The key changes implemented are:

Alias Conflict Resolution: The about command had the alias -a, which conflicted with another subcommand. To resolve this, the alias was changed to -a, ensuring uniqueness and preventing command execution ambiguities.

Improved Shell Detection: The isShellInstalled method was refactored for better cross-platform compatibility. The previous implementation checked for shells using fixed paths, which was unreliable across different environments. The new approach utilizes ProcessBuilder with which (on Unix-like systems) and where (on Windows) commands to detect the presence of shells more robustly.

Updated Autocomplete Command Class Reference: The fullyQualifiedClassName parameter used in generating the autocomplete script was updated from "org.buildcli.OptionCommand" to "org.buildcli.BuildCLI". This change ensures that the autocomplete script is generated based on the correct main class, reflecting all available subcommand.

How to Test the Changes

To verify the fixes and improvements:

1. Alias Verification:

Run `buildcli --help` and confirm that the alias `-a` is correctly associated with the `about` command and that there are no conflicts with other commands.

2. Autocomplete Functionality Test:
 - Remove any previously generated autocomplete scripts:
  `rm ~/.buildcli-completion.bash`
 - Generate the new autocomplete script:
  `buildcli autocomplete`
  
 - Restart the terminal or source the configuration file:
  `source ~/.bashrc  # or the corresponding file for your shell`
  
  Test the autocomplete by typing `buildcli` followed by [TAB] and verify that the subcommands are correctly suggested.
  
  My test:
  
![image](https://github.com/user-attachments/assets/2334a7dc-462d-45ae-a009-bab3d5f8dcfe)

