### PR TITLE
feat: restrict ASCII Art display to specific commands with aliases

### DIFF
--- a/cli/src/main/java/dev/buildcli/cli/CommandLineRunner.java
+++ b/cli/src/main/java/dev/buildcli/cli/CommandLineRunner.java
@@ -7,7 +7,10 @@ import picocli.CommandLine;
 public class CommandLineRunner {
   public static void main(String[] args) {
     LoggingConfig.configure();
-    BuildCLIService.welcome();
+
+    if (BuildCLIService.shouldShowAsciiArt(args)) {
+      BuildCLIService.welcome();
+    }
 
     var commandLine = new CommandLine(new BuildCLI());
 

--- a/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
+++ b/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
@@ -7,6 +7,7 @@ import dev.buildcli.core.log.SystemOutLogger;
 import dev.buildcli.core.utils.tools.CLIInteractions;
 
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.Attributes;
@@ -47,14 +48,26 @@ public class BuildCLIService {
     if (args.length == 0) {
       return false;
     }
+
+    if (Arrays.asList(args).contains("--help")) {
+      return true;
+    }
+
     Map<String, List<String>> commandAliases = Map.of(
             "p", List.of("p", "project"),
-            "about", List.of("a", "about")
+            "about", List.of("a", "about"),
+            "help", List.of("help", "h")
     );
+
     String mainCommand = args[0];
     if (matchesCommand(mainCommand, commandAliases.get("p"))) {
       return args.length > 1 && (args[1].equals("run") || (args.length > 2 && args[1].equals("i") && args[2].equals("-n")));
     }
+
+    if (matchesCommand(mainCommand, commandAliases.get("help"))) {
+      return true;
+    }
+
     return matchesCommand(mainCommand, commandAliases.get("about"));
   }
 

--- a/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
+++ b/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
@@ -7,6 +7,8 @@ import dev.buildcli.core.log.SystemOutLogger;
 import dev.buildcli.core.utils.tools.CLIInteractions;
 
 import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -39,6 +41,25 @@ public class BuildCLIService {
     System.out.println("|  '--' /'  ''  '|  ||  |\\ `-' |'  '--'\\|  '--.|  |");
     System.out.println("`------'  `----' `--'`--' `---'  `-----'`-----'`--'");
     System.out.println();
+  }
+
+  public static boolean shouldShowAsciiArt(String[] args) {
+    if (args.length == 0) {
+      return false;
+    }
+    Map<String, List<String>> commandAliases = Map.of(
+            "p", List.of("p", "project"),
+            "about", List.of("a", "about")
+    );
+    String mainCommand = args[0];
+    if (matchesCommand(mainCommand, commandAliases.get("p"))) {
+      return args.length > 1 && (args[1].equals("run") || (args.length > 2 && args[1].equals("i") && args[2].equals("-n")));
+    }
+    return matchesCommand(mainCommand, commandAliases.get("about"));
+  }
+
+  private static boolean matchesCommand(String input, List<String> validCommands) {
+    return validCommands != null && validCommands.contains(input);
   }
 
   public static void about() {


### PR DESCRIPTION
## Description
This PR updates the ASCII Art display logic in BuildCLI to ensure it only appears for specific commands. Previously, the ASCII Art was shown for all commands, which cluttered the terminal output. Now, it will only be displayed when executing the following commands:
- `buildcli p i -n myproject` (or `buildcli project i -n myproject`)
- `buildcli p run` (or `buildcli project run`)
- `buildcli about` (or `buildcli a`)
- `buildcli help`
- Any command that ends with `--help` (e.g., `buildcli p --help`, `buildcli config --help`)

For all other commands, the ASCII Art will no longer be displayed, keeping the CLI output cleaner and more concise.

## Related Issues
Fixes #256

## Changes
- [x] Restricted ASCII Art display to specific commands.
- [x] Added support for command aliases (`p` = `project`, `a` = `about`).
- [x] Enabled ASCII Art when the `--help` flag is used.
- [x] Moved ASCII Art logic to `BuildCLIService` to improve separation of concerns.
- [x] Refactored logic to ensure efficient command validation.

## Testing
The changes were tested by executing different commands in BuildCLI and verifying that the ASCII Art only appears in the correct scenarios.

## Additional Notes
This change improves the user experience by reducing unnecessary output in the terminal while maintaining the visual identity of BuildCLI for key commands.