### PR TITLE
feat: Add issue templates for bug reports, feature requests, documentation updates, and others

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report 🐞
+description: File a bug report
+title: "[Bug] "
+labels: bug
+body:
+- type: checkboxes
+  id: existing-issue
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  id: what-happened
+  attributes:
+    label: Describe the bug
+    description: A concise description of what you are experiencing.
+    placeholder: Tell us what you see!
+  validations:
+    required: true
+- type: textarea
+  id: expected-behaviour
+  attributes:
+    label: Expected behavior
+    description: A clear and concise description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  id: screenshots
+  attributes:
+    label: Add Screenshots
+    description: Attach screenshots to illustrate the issue (if applicable).
+- type: dropdown
+  id: devices
+  attributes:
+    label: On which device are you experiencing this bug?
+    multiple: true
+    options:
+    - Android
+    - iPhone
+    - Linux
+    - Chrome
+    - Windows
+- type: checkboxes
+  id: terms
+  attributes:
+    label: Record
+    options:
+    - label: "I have read the Contributing Guidelines"
+      required: true
+    - label: "I have starred the repository"
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,11 +37,9 @@ body:
     label: On which device are you experiencing this bug?
     multiple: true
     options:
-    - Android
-    - iPhone
-    - Linux
-    - Chrome
     - Windows
+    - MacOS
+    - Linux
 - type: checkboxes
   id: terms
   attributes:

--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -1,0 +1,58 @@
+name: Documentation Update 📝
+description: Improve Documentation
+title: "[Documentation Update]: "
+labels: 'documentation'
+body:
+- type: checkboxes
+  id: existing-issue
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the updates you want to make.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  id: issue-description
+  attributes:
+    label: Issue Description
+    description: Please provide a clear description of the documentation update you are suggesting.
+    placeholder: Describe the improvement or correction you'd like to see in the documentation.
+  validations:
+    required: true
+- type: textarea
+  id: suggested-change
+  attributes:
+    label: Suggested Change
+    description: Provide details of the proposed change to the documentation.
+    placeholder: Explain how the documentation should be updated or corrected.
+  validations:
+    required: true
+- type: textarea
+  id: rationale
+  attributes:
+    label: Rationale
+    description: Why is this documentation update necessary or beneficial?
+    placeholder: Explain the importance or reasoning behind the suggested change.
+  validations:
+    required: False
+- type: dropdown
+  id: urgency
+  attributes:
+    label: Urgency
+    description: How urgently do you believe this documentation update is needed?
+    options:
+    - High
+    - Medium
+    - Low
+    default: 0
+  validations:
+    required: true
+- type: checkboxes
+  id: terms
+  attributes:
+    label: Record
+    options:
+    - label: "I have read the Contributing Guidelines"
+      required: true
+    - label: "I have starred the repository"
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,61 @@
+name: Feature Request ✨
+description: Suggest a feature
+title: "[Feature Request] "
+labels: enhancement
+body:
+- type: checkboxes
+  id: existing-issue
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for this feature.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  id: feature-description
+  attributes:
+    label: Feature Description
+    description: Please provide a detailed description of the feature you are requesting.
+    placeholder: Describe the new feature or enhancement you'd like to see.
+  validations:
+    required: true
+- type: textarea
+  id: use-case
+  attributes:
+    label: Use Case
+    description: How would this feature enhance your use of the project?
+    placeholder: Describe a specific use case or scenario where this feature would be beneficial.
+  validations:
+    required: true
+- type: textarea
+  id: benefits
+  attributes:
+    label: Benefits
+    description: What benefits would this feature bring to the project or community?
+    placeholder: Explain the advantages of implementing this feature.
+- type: textarea
+  id: screenshots
+  attributes:
+    label: Add Screenshots
+    description: If any...
+- type: dropdown
+  id: priority
+  attributes:
+    label: Priority
+    description: How important is this feature to you?
+    options:
+    - High
+    - Medium
+    - Low
+    default: 0
+  validations:
+    required: true
+- type: checkboxes
+  id: terms
+  attributes:
+    label: Record
+    options:
+    - label: "I have read the Contributing Guidelines"
+      required: true
+    - label: "I have starred the repository"
+      required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,41 @@
+name: Other
+description: Use this for any other issues. Please do NOT create blank issues
+title: '[OTHER] write a small description here'
+body:
+- type: textarea
+  id: issuedescription
+  attributes:
+    label: What would you like to share?
+    description: Provide a clear and concise explanation of your issue.
+  validations:
+    required: true
+
+- type: dropdown
+  id: browser
+  attributes:
+    label: '✨ Browser'
+    description: 'What browser are you using ?'
+    options:
+    - Google Chrome
+    - Brave
+    - Arc
+    - Safari
+    - Microsoft Edge
+    - Mozilla Firefox
+    - Other
+  validations:
+    required: true
+
+- type: checkboxes
+  id: no-duplicate-issues
+  attributes:
+    label: 'Checklist 🚀'
+    options:
+    - label: "I checked and didn't find similar issue"
+      required: true
+
+    - label: 'I have read the Contributing Guidelines'
+      required: true
+
+    - label: 'I am willing to work on this issue (blank for no).'
+      required: false


### PR DESCRIPTION
fixes #264 

- Created `.github/ISSUE_TEMPLATE/` directory (if not already present)
- Added Bug Report template
- Added Feature Request template
- Added Documentation Update template
- Added Others template

![Screenshot 2025-03-01 212306](https://github.com/user-attachments/assets/dfef2bb9-2f17-4099-81c6-4ab8d99be760)
