### PR TITLE
#266: Fix NullPointerException and FileNotFoundException in Changelog…

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -113,6 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+								<version>3.13.0</version>
                 <configuration>
                     <source>21</source>
                     <target>21</target>
@@ -121,6 +122,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.2.5</version>
 				<configuration>
 					<forkCount>1</forkCount>
 					<argLine>

--- a/cli/src/main/java/dev/buildcli/cli/commands/ChangelogCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/ChangelogCommand.java
@@ -1,7 +1,7 @@
 package dev.buildcli.cli.commands;
 
 import dev.buildcli.core.domain.BuildCLICommand;
-import org.buildcli.utils.FileTypes;
+import dev.buildcli.core.utils.FileTypes;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
@@ -20,7 +20,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.buildcli.constants.ChangelogConstants.ORDERED_SECTIONS;
+import static dev.buildcli.core.constants.ChangelogConstants.ORDERED_SECTIONS;
 
 @Command(
         name = "changelog",

--- a/cli/src/main/java/dev/buildcli/cli/commands/ChangelogCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/ChangelogCommand.java
@@ -1,6 +1,7 @@
 package dev.buildcli.cli.commands;
 
 import dev.buildcli.core.domain.BuildCLICommand;
+import java.nio.file.Paths;
 import org.buildcli.utils.FileTypes;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -109,12 +110,15 @@ public class ChangelogCommand implements BuildCLICommand {
     }
 
     protected String formatOutputFile(String fileName, String format) {
-        if (fileName == null | fileName.isBlank()) {
+        if (fileName == null || fileName.isBlank()) {
             return "CHANGELOG" + FileTypes.fromExtension(format);
         }
         String outputFileName = fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : fileName;
+        String[] tokens = outputFileName.split(Pattern.quote(File.separator));
+        String path = Paths.get("", tokens).toString();
         String extension = FileTypes.fromExtension(format);
-        return outputFile == null ? "CHANGELOG" + extension : Path.of(outputFileName + extension).toString();
+
+        return outputFile == null ? "CHANGELOG" + extension : path + extension;
     }
 
     protected void generateChangeLog(String releaseVersion, String outputFile, List<String> includeTypes) throws IOException, GitAPIException {

--- a/cli/src/main/java/dev/buildcli/cli/commands/ChangelogCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/ChangelogCommand.java
@@ -1,7 +1,6 @@
 package dev.buildcli.cli.commands;
 
 import dev.buildcli.core.domain.BuildCLICommand;
-import java.nio.file.Paths;
 import org.buildcli.utils.FileTypes;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -114,11 +113,8 @@ public class ChangelogCommand implements BuildCLICommand {
             return "CHANGELOG" + FileTypes.fromExtension(format);
         }
         String outputFileName = fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : fileName;
-        String[] tokens = outputFileName.split(Pattern.quote(File.separator));
-        String path = Paths.get("", tokens).toString();
         String extension = FileTypes.fromExtension(format);
-
-        return outputFile == null ? "CHANGELOG" + extension : path + extension;
+        return outputFile == null ? "CHANGELOG" + extension : Path.of(outputFileName + extension).toString();
     }
 
     protected void generateChangeLog(String releaseVersion, String outputFile, List<String> includeTypes) throws IOException, GitAPIException {

--- a/core/src/main/java/dev/buildcli/core/constants/ChangelogConstants.java
+++ b/core/src/main/java/dev/buildcli/core/constants/ChangelogConstants.java
@@ -1,4 +1,4 @@
-package org.buildcli.constants;
+package dev.buildcli.core.constants;
 
 import java.util.List;
 

--- a/core/src/main/java/dev/buildcli/core/utils/FileTypes.java
+++ b/core/src/main/java/dev/buildcli/core/utils/FileTypes.java
@@ -1,4 +1,4 @@
-package org.buildcli.utils;
+package dev.buildcli.core.utils;
 
 public enum FileTypes {
     MARKDOWN("markdown", ".md"),


### PR DESCRIPTION
fixes #266 
- Replaced the Bitwise OR (|) operator which does not short-circuit when used with boolean values with OR (||) operator to solve the NullPointerException.
- Replaced Path.of() with Paths.get() which should create the path in a platform-independent way.