### PR TITLE
fix: update repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Welcome to BuildCLI - Java Project Management!
 
 **BuildCLI** is a command-line interface (CLI) tool for managing and automating common tasks in Java project development. It allows you to create, compile, manage dependencies, and run Java projects directly from the terminal, simplifying the development process.
 
-- **Repository:** [https://github.com/wheslleyrimar/buildcli](https://github.com/wheslleyrimar/buildcli)
+- **Repository:** [https://github.com/BuildCLI/BuildCLI](https://github.com/BuildCLI/BuildCLI)
 - **License:** [MIT](https://opensource.org/licenses/MIT)
 
 ---
@@ -39,7 +39,7 @@ Welcome to BuildCLI - Java Project Management!
 - **Run Project**: Starts the project directly from the CLI using Spring Boot.
 - **Dockerize Project**: Generates a Dockerfile for the project, allowing easy containerization.
 - **Build and Run Docker Container**: Builds and runs the Docker container using the generated Dockerfile.
-- **CI/CD Integration**: Automatically generates configuration files por CI/CD tools (e.g., Jenkins, Github Actions) and triggers pipelines based on project changes.
+- **CI/CD Integration**: Automatically generates configuration files por CI/CD tools (e.g., Jenkins, GitHub Actions) and triggers pipelines based on project changes.
 - **Changelog Generation**: Automatically generates a structured changelog by analyzing the Git commit history, facilitating the understanding of changes between releases.
 ---
 
@@ -182,7 +182,7 @@ buildcli project run docker
 
 ### 10. Set Up CI/CD Integration
 
-Generates configuration files for CI/CD tools and prepares the project for automated pipelines. Supports Jenkins, Gitlab and Github Actions.
+Generates configuration files for CI/CD tools and prepares the project for automated pipelines. Supports Jenkins, Gitlab and GitHub Actions.
 
 ```bash
 buildcli project add pipeline github

--- a/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
+++ b/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
@@ -78,7 +78,7 @@ public class BuildCLIService {
   public static void about() {
     SystemOutLogger.log("BuildCLI is a command-line interface (CLI) tool for managing and automating common tasks in Java project development.\n" +
         "It allows you to create, compile, manage dependencies, and run Java projects directly from the terminal, simplifying the development process.\n");
-    SystemOutLogger.log("Visit the repository for more details: https://github.com/wheslleyrimar/BuildCLI\n");
+    SystemOutLogger.log("Visit the repository for more details: https://github.com/BuildCLI/BuildCLI\n");
 
     gitExec.showContributors(localRepository, "https://github.com/BuildCLI/BuildCLI.git");
   }


### PR DESCRIPTION
## Description
Updated the repository link in the "about" command of BuildCLI to reflect the new organization URL

## Changes
- [x] Updated the repository link in the "about" command of BuildCLI
- [x] Changed the URL from the personal repository (`wheslleyrimar`) to the official BuildCLI organization

### Checklist
- [x] My code follows the project's code style
