### PR TITLE
fix: correct incorrect auto update status message #288

### DIFF
--- a/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
+++ b/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
@@ -88,7 +88,7 @@ public class BuildCLIService {
 
     var exitedCode = process.run();
 
-    if (exitedCode != 0) {
+    if (exitedCode == 0) {
       System.out.println("Success...");
     } else {
       System.out.println("Failure...");


### PR DESCRIPTION
I have adjusted the logic of the generateBuildCLIJar() method to correctly display success and failure messages based on the update process exit code.

🔹 Commit: e0c91353420b505bf7c6fd1ee1e06abb574e5acf

🔹 Issue: #288

Please review it and let me know if any further changes are needed.