### PR TITLE
fix: Handle missing profile and properties files gracefully

### DIFF
--- a/cli/src/main/java/dev/buildcli/cli/commands/RunCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/RunCommand.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -86,10 +87,18 @@ public class RunCommand implements BuildCLICommand {
   private Properties loadProfileProperties(String profile) {
     Properties properties = new Properties();
     String propertiesFile = "src/main/resources/application-" + profile + ".properties";
+    Path propertiesFilePath = Paths.get(propertiesFile);
+    String messageWarning = "Profile properties file not found: " + propertiesFile + ". Continuing with empty properties.";
+
+    if (!Files.exists(propertiesFilePath)) {
+      logger.warning(messageWarning);
+      return properties;
+    }
+
     try (InputStream input = Files.newInputStream(Paths.get(propertiesFile))) {
       properties.load(input);
     } catch (IOException e) {
-      logger.log(Level.SEVERE, "Failed to load profile properties file: " + propertiesFile, e);
+      logger.warning(messageWarning);
     }
     return properties;
   }

--- a/cli/src/main/java/dev/buildcli/cli/commands/project/set/EnvironmentCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/project/set/EnvironmentCommand.java
@@ -14,7 +14,7 @@ import java.nio.file.StandardOpenOption;
 @Command(name = "environment", aliases = {"env", "e"}, description = "", mixinStandardHelpOptions = true)
 public class EnvironmentCommand implements BuildCLICommand {
   private final Logger logger = LoggerFactory.getLogger(EnvironmentCommand.class.getName());
-  private final Path configPath = Path.of("environment.config");;
+  private final Path configPath = Path.of("environment.config");
 
   @Parameters(index = "0")
   private String environment;
@@ -25,10 +25,8 @@ public class EnvironmentCommand implements BuildCLICommand {
       String content = "active.profile=" + environment; // Formata a string no formato chave-valor
       Files.writeString(configPath, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
       logger.info("Environment set to: {}", environment);
-      System.out.println("Environment set to: " + environment);
     } catch (IOException e) {
       logger.error("Failed to set environment: {}", e.getMessage());
-      System.err.println("Error: Could not set environment.");
     }
   }
 }

--- a/core/src/main/java/dev/buildcli/core/project/ProjectRunner.java
+++ b/core/src/main/java/dev/buildcli/core/project/ProjectRunner.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -95,10 +96,17 @@ public class ProjectRunner {
     private Properties loadProfileProperties(String profile) {
         Properties properties = new Properties();
         String propertiesFile = "src/main/resources/application-" + profile + ".properties";
+        Path propertiesFilePath = Paths.get(propertiesFile);
+        String messageWarning = "Profile properties file not found: " + propertiesFile + ". Continuing with empty properties.";
+
+        if (!Files.exists(propertiesFilePath)) {
+            logger.warning(messageWarning);
+            return properties;
+        }
         try (InputStream input = Files.newInputStream(Paths.get(propertiesFile))) {
             properties.load(input);
         } catch (IOException e) {
-            logger.log(Level.SEVERE, "Failed to load profile properties file: " + propertiesFile, e);
+            logger.warning(messageWarning);
         }
         return properties;
     }

--- a/core/src/main/java/dev/buildcli/core/utils/ProfileManager.java
+++ b/core/src/main/java/dev/buildcli/core/utils/ProfileManager.java
@@ -1,11 +1,13 @@
 package dev.buildcli.core.utils;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.nio.file.Files.newBufferedReader;
 
 public class ProfileManager {
     private static final Logger logger = Logger.getLogger(ProfileManager.class.getName());
@@ -13,11 +15,11 @@ public class ProfileManager {
 
     public String getActiveProfile() {
         Properties properties = new Properties();
-        try {
-            properties.load(Files.newBufferedReader(Paths.get(CONFIG_FILE)));
+        try (BufferedReader reader = newBufferedReader(Paths.get(CONFIG_FILE))) {
+            properties.load(reader);
             return properties.getProperty("active.profile");
         } catch (IOException e) {
-            logger.log(Level.SEVERE, "Failed to load environment configuration", e);
+            logger.log(Level.WARNING, "Environment configuration file not found. Using default profile.");
             return "default"; // Retorno padrão se o perfil não estiver definido
         }
     }


### PR DESCRIPTION
### Merge Request


#### **Description**  
This PR addresses issue #324, where running `buildcli p run` without an active profile or missing configuration files resulted in `NoSuchFileException` errors in the logs. The changes ensure a more graceful handling of missing files and improve the user experience by providing clear warnings instead of throwing exceptions.

---

### **Changes**

#### **Graceful Handling of Missing Files**
- The `getActiveProfile` method now logs a warning and defaults to the "default" profile if `environment.config` is missing.
- The `loadProfileProperties` method logs a warning and returns empty properties if the profile-specific properties file (e.g., `application-default.properties`) is missing.

#### **Improved Logging**
- Replaced exception throwing with warning logs for missing files, ensuring cleaner and more user-friendly output.

#### **Code Readability**
- Added descriptive warning messages to inform users about missing files and the fallback behavior.

---

### **Impact**
- Users will no longer see `NoSuchFileException` errors in the logs when running `buildcli p run` without an active profile or missing configuration files.
- The system will default to the "default" profile and empty properties, ensuring uninterrupted execution with clear warnings.


---

### **Related Issue**
Fixes #324

---

### **Why This Matters**
This fix improves the usability and reliability of the `buildcli p run` command, ensuring that users are not confronted with confusing error messages when configuration files are missing. Instead, they receive clear warnings, and the system continues to function with default values.

---

### **Screenshots**

![image](https://github.com/user-attachments/assets/61f5bf29-3677-45fe-b1b1-0fb79b3e42c6)


