### PR TITLE
feat: add bug report command (WIP)

### DIFF
--- a/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
+++ b/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
@@ -2,6 +2,7 @@ package dev.buildcli.cli;
 
 import dev.buildcli.cli.commands.*;
 import dev.buildcli.cli.commands.AiCommand;
+import dev.buildcli.cli.commands.bug.BugCommand;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
@@ -12,7 +13,7 @@ import picocli.CommandLine.HelpCommand;
     subcommands = {
         AboutCommand.class, AiCommand.class, AutocompleteCommand.class, ChangelogCommand.class, ConfigCommand.class,
         DoctorCommand.class, HookCommand.class, ProjectCommand.class, PluginCommand.class, RunCommand.class,
-        VersionCommand.class, HelpCommand.class
+        VersionCommand.class, HelpCommand.class, BugCommand.class
     }
 )
 public class BuildCLI {

--- a/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
+++ b/cli/src/main/java/dev/buildcli/cli/BuildCLI.java
@@ -2,8 +2,7 @@ package dev.buildcli.cli;
 
 import dev.buildcli.cli.commands.*;
 import dev.buildcli.cli.commands.AiCommand;
-import dev.buildcli.cli.commands.bug.BugCommand;
-import picocli.CommandLine;
+import dev.buildcli.cli.commands.BugCommand;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
 

--- a/cli/src/main/java/dev/buildcli/cli/commands/BugCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/BugCommand.java
@@ -1,6 +1,7 @@
 package dev.buildcli.cli.commands;
 
 import dev.buildcli.core.domain.BuildCLICommand;
+import dev.buildcli.core.utils.JavaUtils;
 import dev.buildcli.core.utils.OS;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
@@ -43,7 +44,7 @@ public class BugCommand implements BuildCLICommand {
                 - OS: %s
                 - Architecture: %s
                 - Java Version: %s
-                """.formatted(buildCliVersion, OS.getOSName(), OS.getArchitecture(), OS.getJavaVersion());
+                """.formatted(buildCliVersion, OS.getOSName(), OS.getArchitecture(), JavaUtils.getJavaVersion());
 
         String encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8);
         String fullUrl = ISSUE_URL + encodedBody;

--- a/cli/src/main/java/dev/buildcli/cli/commands/BugCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/BugCommand.java
@@ -1,12 +1,13 @@
 package dev.buildcli.cli.commands;
 
 import dev.buildcli.core.domain.BuildCLICommand;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import java.awt.Desktop;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.Callable;
+import org.slf4j.Logger;
 
 @Command(
         name = "bug",
@@ -14,7 +15,7 @@ import java.util.concurrent.Callable;
         mixinStandardHelpOptions = true
 )
 public class BugCommand implements BuildCLICommand {
-
+    private static final Logger logger = LoggerFactory.getLogger(BugCommand.class);
     private static final String ISSUE_URL = "https://github.com/BuildCLI/BuildCLI/issues/new?body=";
 
     @Override
@@ -52,8 +53,8 @@ public class BugCommand implements BuildCLICommand {
 
         openBrowser(fullUrl);
 
-        System.out.println("Opened GitHub issue template in your browser. If it didn’t open, please visit:");
-        System.out.println(fullUrl);
+       logger.info("Opened GitHub issue template in your browser. If it didn’t open, please visit:");
+       logger.info(fullUrl);
     }
 
     private String getBuildCliVersion() {
@@ -66,11 +67,11 @@ public class BugCommand implements BuildCLICommand {
             if (Desktop.isDesktopSupported()) {
                 Desktop.getDesktop().browse(new URI(url));
             } else {
-                System.err.println("Desktop browsing not supported. Please open the following URL manually:");
-                System.err.println(url);
+                logger.warn("Desktop browsing not supported. Please open the following URL manually:");
+                logger.warn(url);
             }
         } catch (Exception e) {
-            System.err.println("Failed to open browser: " + e.getMessage());
+            logger.error("Failed to open browser: {}", e.getMessage(), e);
         }
     }
 }

--- a/cli/src/main/java/dev/buildcli/cli/commands/BugCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/BugCommand.java
@@ -1,23 +1,24 @@
-package dev.buildcli.cli.commands.bug;
+package dev.buildcli.cli.commands;
 
-import picocli.CommandLine;
+import dev.buildcli.core.domain.BuildCLICommand;
+import picocli.CommandLine.Command;
 import java.awt.Desktop;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 
-@CommandLine.Command(
+@Command(
         name = "bug",
         description = "Opens a GitHub issue template pre-filled with system and version info, helping you report a bug in BuildCLI.",
         mixinStandardHelpOptions = true
 )
-public class BugCommand implements Callable<Integer> {
+public class BugCommand implements BuildCLICommand {
 
     private static final String ISSUE_URL = "https://github.com/BuildCLI/BuildCLI/issues/new?body=";
 
     @Override
-    public Integer call() throws Exception {
+    public void run() {
         String buildCliVersion = getBuildCliVersion();
         String os = System.getProperty("os.name");
         String arch = System.getProperty("os.arch");
@@ -53,8 +54,6 @@ public class BugCommand implements Callable<Integer> {
 
         System.out.println("Opened GitHub issue template in your browser. If it didn’t open, please visit:");
         System.out.println(fullUrl);
-
-        return 0;
     }
 
     private String getBuildCliVersion() {

--- a/cli/src/main/java/dev/buildcli/cli/commands/BugCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/BugCommand.java
@@ -1,6 +1,7 @@
 package dev.buildcli.cli.commands;
 
 import dev.buildcli.core.domain.BuildCLICommand;
+import dev.buildcli.core.utils.OS;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import java.awt.Desktop;
@@ -21,10 +22,6 @@ public class BugCommand implements BuildCLICommand {
     @Override
     public void run() {
         String buildCliVersion = getBuildCliVersion();
-        String os = System.getProperty("os.name");
-        String arch = System.getProperty("os.arch");
-        String javaVersion = System.getProperty("java.version");
-
         String body = """
                 ### Describe the bug
 
@@ -46,7 +43,7 @@ public class BugCommand implements BuildCLICommand {
                 - OS: %s
                 - Architecture: %s
                 - Java Version: %s
-                """.formatted(buildCliVersion, os, arch, javaVersion);
+                """.formatted(buildCliVersion, OS.getOSName(), OS.getArchitecture(), OS.getJavaVersion());
 
         String encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8);
         String fullUrl = ISSUE_URL + encodedBody;

--- a/cli/src/main/java/dev/buildcli/cli/commands/bug/BugCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/bug/BugCommand.java
@@ -1,0 +1,77 @@
+package dev.buildcli.cli.commands.bug;
+
+import picocli.CommandLine;
+import java.awt.Desktop;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
+
+@CommandLine.Command(
+        name = "bug",
+        description = "Opens a GitHub issue template pre-filled with system and version info, helping you report a bug in BuildCLI.",
+        mixinStandardHelpOptions = true
+)
+public class BugCommand implements Callable<Integer> {
+
+    private static final String ISSUE_URL = "https://github.com/BuildCLI/BuildCLI/issues/new?body=";
+
+    @Override
+    public Integer call() throws Exception {
+        String buildCliVersion = getBuildCliVersion();
+        String os = System.getProperty("os.name");
+        String arch = System.getProperty("os.arch");
+        String javaVersion = System.getProperty("java.version");
+
+        String body = """
+                ### Describe the bug
+
+                <!-- A clear and concise description of what the bug is. -->
+
+                ### Steps to Reproduce
+
+                <!-- Steps to reproduce the behavior: -->
+                1. Go to '...'
+                2. Run command '...'
+                3. See error
+
+                ### Expected behavior
+
+                <!-- A clear and concise description of what you expected to happen. -->
+
+                ### Environment
+                - BuildCLI Version: %s
+                - OS: %s
+                - Architecture: %s
+                - Java Version: %s
+                """.formatted(buildCliVersion, os, arch, javaVersion);
+
+        String encodedBody = URLEncoder.encode(body, StandardCharsets.UTF_8);
+        String fullUrl = ISSUE_URL + encodedBody;
+
+        openBrowser(fullUrl);
+
+        System.out.println("Opened GitHub issue template in your browser. If it didn’t open, please visit:");
+        System.out.println(fullUrl);
+
+        return 0;
+    }
+
+    private String getBuildCliVersion() {
+        // TODO: Retrieve actual BuildCLI version from manifest or config file
+        return "1.0.0"; // Placeholder version
+    }
+
+    private void openBrowser(String url) {
+        try {
+            if (Desktop.isDesktopSupported()) {
+                Desktop.getDesktop().browse(new URI(url));
+            } else {
+                System.err.println("Desktop browsing not supported. Please open the following URL manually:");
+                System.err.println(url);
+            }
+        } catch (Exception e) {
+            System.err.println("Failed to open browser: " + e.getMessage());
+        }
+    }
+}

--- a/core/src/main/java/dev/buildcli/core/utils/JavaUtils.java
+++ b/core/src/main/java/dev/buildcli/core/utils/JavaUtils.java
@@ -1,0 +1,11 @@
+package dev.buildcli.core.utils;
+
+public abstract class JavaUtils {
+
+    private JavaUtils() {}
+
+    public static String getJavaVersion() {
+        return System.getProperty("java.version");
+    }
+
+}

--- a/core/src/main/java/dev/buildcli/core/utils/OS.java
+++ b/core/src/main/java/dev/buildcli/core/utils/OS.java
@@ -28,10 +28,6 @@ public abstract class OS {
         return System.getProperty("os.arch");
     }
 
-    public static String getJavaVersion() {
-        return System.getProperty("java.version");
-    }
-
   public static void cdDirectory(String path){
     try {
         String[] command;

--- a/core/src/main/java/dev/buildcli/core/utils/OS.java
+++ b/core/src/main/java/dev/buildcli/core/utils/OS.java
@@ -20,6 +20,18 @@ public abstract class OS {
     return OS.contains("linux") || OS.contains("nix") || OS.contains("nux") || OS.contains("aix");
   }
 
+    public static String getOSName() {
+        return System.getProperty("os.name");
+    }
+
+    public static String getArchitecture() {
+        return System.getProperty("os.arch");
+    }
+
+    public static String getJavaVersion() {
+        return System.getProperty("java.version");
+    }
+
   public static void cdDirectory(String path){
     try {
         String[] command;
@@ -70,5 +82,4 @@ public abstract class OS {
       }
 
   }
-
 }


### PR DESCRIPTION
## Description
Adds the initial implementation of the `bug` command, which opens a GitHub issue template pre-filled with system and version info. This feature helps users report bugs in BuildCLI more easily.

## Related Issues
#450 

## Changes
- [x] Added `BugCommand` to handle the `buildcli bug` CLI command.
- [x] Implemented logic to open a pre-filled GitHub issue template.
- [x] Included system information such as OS, architecture, and Java version.
- [x] Placeholder version retrieval (`getBuildCliVersion`), to be implemented later.

## Testing
- Manually tested on macOS by running `buildcli bug` and verifying that the correct issue page opens in the browser.
- Checked output when the browser is not supported, ensuring a fallback message is printed.

### Checklist
- [x] My code follows the code style of this project.

## Additional Notes
- Future improvements include dynamically fetching the BuildCLI version from a configuration file or manifest.