### PR TITLE
test: Add unit tests for MavenChecker class

### DIFF
--- a/core/src/test/java/dev/buildcli/core/actions/tools/MavenCheckerTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/tools/MavenCheckerTest.java
@@ -1,7 +1,6 @@
-package dev.buildcli.core.utils.actions;
+package dev.buildcli.core.actions.tools;
 
 import dev.buildcli.core.actions.commandline.MavenProcess;
-import dev.buildcli.core.actions.tools.MavenChecker;
 import dev.buildcli.core.utils.installers.MavenInstaller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/dev/buildcli/core/utils/actions/MavenCheckerTest.java
+++ b/core/src/test/java/dev/buildcli/core/utils/actions/MavenCheckerTest.java
@@ -1,0 +1,105 @@
+package dev.buildcli.core.utils.actions;
+
+import dev.buildcli.core.actions.commandline.MavenProcess;
+import dev.buildcli.core.actions.tools.MavenChecker;
+import dev.buildcli.core.utils.installers.MavenInstaller;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class MavenCheckerTest {
+
+  private MavenChecker mavenChecker;
+
+  @BeforeEach
+  public void setUp() {
+    mavenChecker = new MavenChecker();
+  }
+
+  @Test
+  void testName() {
+    String result = mavenChecker.name();
+    String expected = "Maven";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testIsInstalled_WhenMavenIsInstalled_ShouldReturnTrue() {
+
+    MavenProcess mockProcess = mock(MavenProcess.class);
+
+    when(mockProcess.run()).thenReturn(0);
+
+    try (var mockedStatic = mockStatic(MavenProcess.class)) {
+      mockedStatic.when(MavenProcess::createGetVersionProcessor).thenReturn(mockProcess);
+
+      assertTrue(mavenChecker.isInstalled());
+    }
+  }
+
+  @Test
+  void testIsInstalled_WhenMavenIsNotInstalled_ShouldReturnFalse() {
+
+    MavenProcess mockProcess = mock(MavenProcess.class);
+
+    when(mockProcess.run()).thenReturn(1);
+
+    try (var mockedStatic = mockStatic(MavenProcess.class)) {
+      mockedStatic.when(MavenProcess::createGetVersionProcessor).thenReturn(mockProcess);
+
+      assertFalse(mavenChecker.isInstalled());
+    }
+  }
+
+  @Test
+  void testVersion_WhenMavenIsInstalled_ShouldReturnVersion() {
+
+    MavenProcess mockProcess = mock(MavenProcess.class);
+
+    when(mockProcess.output()).thenReturn(Collections.singletonList("Apache Maven 3.8.5"));
+
+    try (var mockedStatic = mockStatic(MavenProcess.class)) {
+      mockedStatic.when(MavenProcess::createGetVersionProcessor).thenReturn(mockProcess);
+
+      String result = mavenChecker.version();
+      String expected = "3.8.5";
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  void testVersion_WhenMavenIsNotInstalled_ShouldReturnNA() {
+
+    MavenProcess mockProcess = mock(MavenProcess.class);
+
+    when(mockProcess.output()).thenReturn(Collections.emptyList());
+    when(mockProcess.run()).thenReturn(1);
+
+    try (var mockedStatic = mockStatic(MavenProcess.class)) {
+      mockedStatic.when(MavenProcess::createGetVersionProcessor).thenReturn(mockProcess);
+
+      String result = mavenChecker.version();
+      String expected = "N/A";
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  void testInstallInstructions() {
+    String result = mavenChecker.installInstructions();
+    String expected = "Install Maven: https://maven.apache.org/install.html";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFixIssue_ShouldCallInstallMaven() {
+    try (var mockedStatic = mockStatic(MavenInstaller.class)) {
+      mavenChecker.fixIssue();
+      mockedStatic.verify(() -> MavenInstaller.installMaven(), times(1));
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds unit tests for the `MavenChecker` class.

## Related Issues

- **Unit Tests: MavenChecker.java** [#353 ](https://github.com/BuildCLI/BuildCLI/issues/353)  

## Changes

- Added unit tests for the `MavenChecker` class.  
- Covered checks for Maven installation status.  
- Implemented tests to retrieve Maven version when installed and return "N/A" when not installed.  
- Verified that install instructions URL is returned correctly.  
- Ensured `MavenInstaller` is called when `mavenChecker.fixIssue();` with Maven installation.

## Testing

The following unit tests were implemented:

- [x] **`testName()`**: Verifies the name of Maven.  
- [x] **`testIsInstalled_WhenMavenIsInstalled_ShouldReturnTrue()`**: Verifies if Maven is installed (successful process).  
- [x] **`testIsInstalled_WhenMavenIsNotInstalled_ShouldReturnFalse()`**: Verifies if Maven is not installed (failed process).  
- [x] **`testVersion_WhenMavenIsInstalled_ShouldReturnVersion()`**: Ensures the correct Maven version is returned when Maven is installed.  
- [x] **`testVersion_WhenMavenIsNotInstalled_ShouldReturnNA()`**: Ensures "N/A" is returned when Maven is not installed.  
- [x] **`testInstallInstructions()`**: Verifies the installation instructions URL for Maven.  
- [x] **`testFixIssue_ShouldCallInstallMaven()`**: Ensures that `MavenInstaller.installMaven()` is called when fixing Maven installation issues.  

## Checklist

- [x] My code follows the project's code style.  
- [x] I have run tests to confirm that my changes do not break existing functionality.  
