### PR TITLE
Add Unit Tests for Pom.java (Closes #443)

### DIFF
--- a/core/src/test/java/dev/buildcli/core/model/DependencyTest.java
+++ b/core/src/test/java/dev/buildcli/core/model/DependencyTest.java
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Test;
 public class DependencyTest {
 
   @Test
-  void testEmptyConstructor(){
+  void testEmptyConstructor() {
     Dependency dependency = new Dependency();
 
-    //check default vales
+    // check default vales
     Assertions.assertNull(dependency.getGroupId());
     Assertions.assertNull(dependency.getArtifactId());
     Assertions.assertNull(dependency.getVersion());
@@ -26,19 +26,19 @@ public class DependencyTest {
 
     Dependency dependency = new Dependency(groupId, artifactId, version);
 
-    //verify constructor sets fields correctly
+    // verify constructor sets fields correctly
     Assertions.assertEquals(groupId, dependency.getGroupId());
     Assertions.assertEquals(artifactId, dependency.getArtifactId());
     Assertions.assertEquals(version, dependency.getVersion());
 
-    //The other fields should be null
+    // The other fields should be null
     Assertions.assertNull(dependency.getType());
     Assertions.assertNull(dependency.getScope());
     Assertions.assertNull(dependency.getOptional());
   }
 
   @Test
-  void testConstructorWith6Args(){
+  void testConstructorWith6Args() {
     String groupId = "com.example";
     String artifactId = "my-lib";
     String version = "1.2.3";
@@ -46,33 +46,32 @@ public class DependencyTest {
     String scope = "compile";
     String optional = "true";
 
-   Dependency dependency = new Dependency(groupId, artifactId, version, type, scope, optional);
+    Dependency dependency = new Dependency(groupId, artifactId, version, type, scope, optional);
 
-        Assertions.assertEquals(groupId, dependency.getGroupId());
-        Assertions.assertEquals(artifactId, dependency.getArtifactId());
-        Assertions.assertEquals(version, dependency.getVersion());
-        Assertions.assertEquals(type, dependency.getType());
-        Assertions.assertEquals(scope, dependency.getScope());
-        Assertions.assertEquals(optional, dependency.getOptional());
+    Assertions.assertEquals(groupId, dependency.getGroupId());
+    Assertions.assertEquals(artifactId, dependency.getArtifactId());
+    Assertions.assertEquals(version, dependency.getVersion());
+    Assertions.assertEquals(type, dependency.getType());
+    Assertions.assertEquals(scope, dependency.getScope());
+    Assertions.assertEquals(optional, dependency.getOptional());
   }
 
+  @Test
+  void testSettersAndGetters() {
+    Dependency dependency = new Dependency();
 
-   @Test
-    void testSettersAndGetters() {
-        Dependency dependency = new Dependency();
+    dependency.setGroupId("org.demo");
+    dependency.setArtifactId("demo-lib");
+    dependency.setVersion("2.0.1");
+    dependency.setType("war");
+    dependency.setScope("test");
+    dependency.setOptional("false");
 
-        dependency.setGroupId("org.demo");
-        dependency.setArtifactId("demo-lib");
-        dependency.setVersion("2.0.1");
-        dependency.setType("war");
-        dependency.setScope("test");
-        dependency.setOptional("false");
-
-        Assertions.assertEquals("org.demo", dependency.getGroupId());
-        Assertions.assertEquals("demo-lib", dependency.getArtifactId());
-        Assertions.assertEquals("2.0.1", dependency.getVersion());
-        Assertions.assertEquals("war", dependency.getType());
-        Assertions.assertEquals("test", dependency.getScope());
-        Assertions.assertEquals("false", dependency.getOptional());
-    }
+    Assertions.assertEquals("org.demo", dependency.getGroupId());
+    Assertions.assertEquals("demo-lib", dependency.getArtifactId());
+    Assertions.assertEquals("2.0.1", dependency.getVersion());
+    Assertions.assertEquals("war", dependency.getType());
+    Assertions.assertEquals("test", dependency.getScope());
+    Assertions.assertEquals("false", dependency.getOptional());
+  }
 }

--- a/core/src/test/java/dev/buildcli/core/model/PomTest.java
+++ b/core/src/test/java/dev/buildcli/core/model/PomTest.java
@@ -1,0 +1,196 @@
+package dev.buildcli.core.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link Pom} class.
+ *
+ * <p>
+ * These tests verify adding, removing, and managing dependencies
+ * within a Pom instance, as well as related utility methods.
+ * </p>
+ */
+public final class PomTest {
+
+  /**
+   * Tests that a new Pom starts with an empty list of dependencies.
+   */
+  @Test
+  void testDefaultConstructor() {
+    Pom pom = new Pom();
+    Assertions.assertEquals(0, pom.countDependencies(),
+        "New Pom should have zero dependencies");
+    Assertions.assertTrue(pom.getDependencies().isEmpty(),
+        "getDependencies() should return an empty list");
+  }
+
+  /**
+   * Tests adding a dependency using the 'groupId:artifactId:version' format.
+   */
+  @Test
+  void testAddDependencyStringThreeParts() {
+    Pom pom = new Pom();
+    pom.addDependency("org.example:my-lib:1.2.3");
+
+    Assertions.assertEquals(1, pom.countDependencies(),
+        "Should have exactly 1 dependency after adding");
+    Assertions.assertTrue(
+        pom.hasDependency("org.example", "my-lib"),
+        "HasDependency should return true for org.example:my-lib");
+  }
+
+  /**
+   * Tests adding a dependency using the 'groupId:artifactId' format,
+   * which should default the version to 'LATEST'.
+   */
+  @Test
+  void testAddDependencyStringTwoParts() {
+    Pom pom = new Pom();
+    pom.addDependency("com.test:demo-lib");
+
+    Assertions.assertEquals(1, pom.countDependencies(),
+        "Should have exactly 1 dependency after adding");
+    Assertions.assertTrue(
+        pom.hasDependency("com.test", "demo-lib"),
+        "HasDependency should return true for com.test:demo-lib");
+
+    // Check if version was set to 'LATEST'
+    Dependency dep = pom.getDependencies().get(0);
+    Assertions.assertEquals("LATEST", dep.getVersion(),
+        "Expected 'LATEST' as the default version");
+  }
+
+  /**
+   * Tests removing a dependency by string format 'groupId:artifactId'.
+   */
+  @Test
+  void testRemoveDependencyString() {
+    Pom pom = new Pom();
+    pom.addDependency("com.remove:lib:2.0.0");
+    Assertions.assertEquals(1, pom.countDependencies(),
+        "Should have 1 dependency after adding");
+
+    pom.rmDependency("com.remove:lib");
+    Assertions.assertEquals(0, pom.countDependencies(),
+        "Should have zero dependencies after removal");
+  }
+
+  /**
+   * Tests adding a dependency directly by groupId/artifactId/version parameters.
+   */
+  @Test
+  void testAddDependencyParameters() {
+    Pom pom = new Pom();
+    pom.addDependency("org.test", "artifact-demo", "4.5.6");
+    Assertions.assertEquals(1, pom.countDependencies(),
+        "Should have 1 dependency");
+    Assertions.assertTrue(pom.hasDependency("org.test", "artifact-demo"),
+        "Should confirm the newly added dependency exists");
+  }
+
+  /**
+   * Tests removing a dependency by groupId/artifactId parameters.
+   */
+  @Test
+  void testRemoveDependencyParameters() {
+    Pom pom = new Pom();
+    pom.addDependency("org.test", "rem-lib", "1.0");
+    Assertions.assertEquals(1, pom.countDependencies());
+
+    pom.rmDependency("org.test", "rem-lib");
+    Assertions.assertEquals(0, pom.countDependencies(),
+        "Dependency should be removed successfully");
+  }
+
+  /**
+   * Tests the getDependencyFormatted() method returns non-empty
+   * XML when dependencies are present.
+   */
+  @Test
+  void testGetDependencyFormatted() {
+    Pom pom = new Pom();
+    pom.addDependency("com.example", "format-test", "1.1.1");
+    String formatted = pom.getDependencyFormatted();
+
+    Assertions.assertNotNull(formatted,
+        "Should return a formatted XML string");
+    Assertions.assertTrue(formatted.contains("<dependencies>"),
+        "Result should contain <dependencies> tag");
+    Assertions.assertTrue(formatted.contains("com.example"),
+        "Result should contain the groupId");
+    Assertions.assertTrue(formatted.contains("format-test"),
+        "Result should contain the artifactId");
+    Assertions.assertTrue(formatted.contains("1.1.1"),
+        "Result should contain the version");
+  }
+
+  /**
+   * Tests hasDependency(String, String) returns false if not found.
+   */
+  @Test
+  void testHasDependencyNotPresent() {
+    Pom pom = new Pom();
+    pom.addDependency("com.example", "my-lib");
+    boolean result = pom.hasDependency("com.foo", "bar");
+    Assertions.assertFalse(result,
+        "Should return false for non-existent dependency");
+  }
+
+  /**
+   * Tests the overloaded hasDependency(Dependency) method
+   * by adding a dependency object and confirming it is recognized.
+   */
+  @Test
+  void testHasDependencyByObject() {
+    Pom pom = new Pom();
+    Dependency d = new Dependency("com.test", "obj-lib", "2.2.2");
+    // Add the dependency via parameters
+    pom.addDependency(d.getGroupId(), d.getArtifactId(), d.getVersion());
+
+    Assertions.assertTrue(pom.hasDependency(d),
+        "Should return true for the same dependency object");
+  }
+
+  /**
+   * Tests countDependencies() accurately reflects the number of added deps.
+   */
+  @Test
+  void testCountDependencies() {
+    Pom pom = new Pom();
+    pom.addDependency("group1:art1:1.0");
+    pom.addDependency("group2:art2:2.0");
+
+    Assertions.assertEquals(2, pom.countDependencies(),
+        "Should have 2 dependencies in total");
+  }
+
+  /**
+   * Tests getDependency(Dependency) retrieves the correct object.
+   */
+  @Test
+  void testGetDependency() {
+    Pom pom = new Pom();
+    Dependency d = new Dependency("com.get", "sample", "9.9.9");
+    pom.addDependency(d.getGroupId(), d.getArtifactId(), d.getVersion());
+
+    Dependency found = pom.getDependency(d);
+    Assertions.assertNotNull(found, "Should find the dependency object");
+    Assertions.assertEquals("com.get", found.getGroupId());
+    Assertions.assertEquals("sample", found.getArtifactId());
+    Assertions.assertEquals("9.9.9", found.getVersion());
+  }
+
+  /**
+   * Tests the toString() representation includes groupId/artifactId.
+   */
+  @Test
+  void testToString() {
+    Pom pom = new Pom();
+    pom.addDependency("com.to", "string-lib", "1.0");
+    String str = pom.toString();
+
+    Assertions.assertTrue(str.contains("com.to:string-lib:1.0"),
+        "toString() should include the new dependency");
+  }
+}

--- a/core/src/test/resources/pom-core-test/pom.xml
+++ b/core/src/test/resources/pom-core-test/pom.xml
@@ -1,0 +1,25 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.coretest</groupId>
+  <artifactId>pom-core-test</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <!-- We'll start with three dependencies -->
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>dep1</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>dep2</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>dep3</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/core/src/test/resources/pom-core-test/pom.xml.versionsBackup
+++ b/core/src/test/resources/pom-core-test/pom.xml.versionsBackup
@@ -1,0 +1,14 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>versions-backup</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.temp</groupId>
+      <artifactId>temp-lib</artifactId>
+      <version>0.0.1</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/core/src/test/resources/pom-utils-test/non-dependencies-pom.xml
+++ b/core/src/test/resources/pom-utils-test/non-dependencies-pom.xml
@@ -1,0 +1,8 @@
+<!-- non-dependencies-pom.xml (example) -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-sample</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <!-- Notice: No <dependencies> tag here -->
+</project>

--- a/core/src/test/resources/pom-utils-test/pom.xml
+++ b/core/src/test/resources/pom-utils-test/pom.xml
@@ -1,0 +1,15 @@
+<!-- pom.xml (example for testing) -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.example</groupId>
+  <artifactId>test-pom</artifactId>
+  <version>1.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.foo</groupId>
+      <artifactId>bar-lib</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
## Summary
Adds a new test class, `PomTest.java`, to cover:

- Adding dependencies by string (`groupId:artifactId:version`).
- Removing dependencies (both string and parameter-based).
- Verifying `hasDependency(...)` checks.
- Testing `getDependency(...)`, `countDependencies()`, and `toString()`.
- Ensuring `getDependencyFormatted()` returns valid XML.

## Changes
- Created `PomTest.java` under `core/src/test/java/dev/buildcli/core/model`.
- Verified edge cases (e.g., default version = "LATEST" for 2-part dep strings).

## Closes
Closes #443
