### PR TITLE
test: Add unit tests for GradleChecker class

### DIFF
--- a/core/src/test/java/dev/buildcli/core/actions/tools/GradleCheckerTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/tools/GradleCheckerTest.java
@@ -1,0 +1,103 @@
+package dev.buildcli.core.actions.tools;
+
+import dev.buildcli.core.actions.commandline.GradleProcess;
+import dev.buildcli.core.utils.installers.GradleInstaller;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class GradleCheckerTest {
+
+    private GradleChecker gradleChecker = new GradleChecker();
+
+    @Test
+    void testName() {
+      String result = gradleChecker.name();
+      String expected = "Gradle";
+      assertEquals(expected, result);
+    }
+
+    @Test
+    void testIsInstalled_WhenGradleIsInstalled_ShouldReturnTrue() {
+      GradleProcess mockProcess = mock(GradleProcess.class);
+      when(mockProcess.run()).thenReturn(0);
+
+      try (var mockedStatic = mockStatic(GradleProcess.class)) {
+        mockedStatic.when(GradleProcess::createGetVersionProcess).thenReturn(mockProcess);
+        assertTrue(gradleChecker.isInstalled());
+      }
+    }
+
+    @Test
+    void testIsInstalled_WhenGradleIsNotInstalled_ShouldReturnFalse() {
+      GradleProcess mockProcess = mock(GradleProcess.class);
+      when(mockProcess.run()).thenReturn(1);
+
+      try (var mockedStatic = mockStatic(GradleProcess.class)) {
+        mockedStatic.when(GradleProcess::createGetVersionProcess).thenReturn(mockProcess);
+        assertFalse(gradleChecker.isInstalled());
+      }
+    }
+
+    @Test
+    void testVersion_WhenGradleIsInstalled_ShouldReturnVersion() {
+      GradleProcess mockProcess = mock(GradleProcess.class);
+      when(mockProcess.output()).thenReturn(Collections.singletonList("Gradle 3.8.5"));
+
+      try (var mockedStatic = mockStatic(GradleProcess.class)) {
+        mockedStatic.when(GradleProcess::createGetVersionProcess).thenReturn(mockProcess);
+        String result = gradleChecker.version();
+        String expected = "3.8.5";
+        assertEquals(expected, result);
+      }
+    }
+
+    @Test
+    void testVersion_WhenGradleIsInstalled_ButOutputIsMalformed_ShouldReturnNA() {
+      GradleProcess mockProcess = mock(GradleProcess.class);
+      when(mockProcess.run()).thenReturn(0);
+      when(mockProcess.output()).thenReturn(Collections.singletonList("Some random text"));
+
+      try (MockedStatic<GradleProcess> mockedStatic = mockStatic(GradleProcess.class)) {
+        mockedStatic.when(GradleProcess::createGetVersionProcess).thenReturn(mockProcess);
+        assertEquals("N/A", gradleChecker.version());
+      }
+    }
+
+    @Test
+    void testVersion_WhenGradleIsNotInstalled_ShouldReturnNA() {
+      GradleProcess mockProcess = mock(GradleProcess.class);
+      when(mockProcess.output()).thenReturn(Collections.emptyList());
+      when(mockProcess.run()).thenReturn(1);
+
+      try (var mockedStatic = mockStatic(GradleProcess.class)) {
+        mockedStatic.when(GradleProcess::createGetVersionProcess).thenReturn(mockProcess);
+        String result = gradleChecker.version();
+        String expected = "N/A";
+        assertEquals(expected, result);
+      }
+    }
+
+    @Test
+    void testInstall_Instructions() {
+      String result = gradleChecker.installInstructions();
+      String expected = "Install Gradle: https://gradle.org/install/";
+      assertEquals(expected, result);
+    }
+
+  @Test
+  void testFixIssueCallsGradleInstaller() {
+    try (MockedStatic<GradleInstaller> mockedStatic = Mockito.mockStatic(GradleInstaller.class)) {
+      GradleChecker fixer = new GradleChecker();
+      fixer.fixIssue();
+
+      mockedStatic.verify(GradleInstaller::installGradle, times(1));
+    }
+  }
+}


### PR DESCRIPTION
## Description  
This PR adds unit tests for the `GradleChecker` class.  

## Related Issues  
- **Unit Tests: GradleChecker.java** [#355](https://github.com/BuildCLI/BuildCLI/issues/355)  

## Changes  
- Added unit tests for the `GradleChecker` class.  
- Covered checks for Gradle installation status.  
- Implemented tests to retrieve Gradle version when installed and return "N/A" when not installed or output is malformed.  
- Verified that install instructions URL is returned correctly.  
- Ensured `GradleInstaller` is called when `gradleChecker.fixIssue()` is invoked.  

## Testing  
The following unit tests were implemented:  

- [x] **`testName()`**: Verifies the tool name is correctly returned as "Gradle".  
- [x] **`testIsInstalled_WhenGradleIsInstalled_ShouldReturnTrue()`**: Validates Gradle installation detection (exit code 0).  
- [x] **`testIsInstalled_WhenGradleIsNotInstalled_ShouldReturnFalse()`**: Validates Gradle absence detection (exit code 1).  
- [x] **`testVersion_WhenGradleIsInstalled_ShouldReturnVersion()`**: Extracts version from valid Gradle output (e.g., "3.8.5").  
- [x] **`testVersion_WhenGradleIsInstalled_ButOutputIsMalformed_ShouldReturnNA()`**: Returns "N/A" for unparseable version output.  
- [x] **`testVersion_WhenGradleIsNotInstalled_ShouldReturnNA()`**: Returns "N/A" when Gradle is not installed.  
- [x] **`testInstall_Instructions()`**: Confirms installation URL matches "https://gradle.org/install/".  
- [x] **`testFixIssueCallsGradleInstaller()`**: Ensures `GradleInstaller.installGradle()` is invoked during `fixIssue()`.  

## Checklist  
- [x] My code follows the project's code style.  
- [x] I have run tests to confirm my changes do not break existing functionality.  