### PR TITLE
test: Add unit tests for DockerChecker class

### DIFF
--- a/core/src/test/java/dev/buildcli/core/actions/tools/DockerCheckerTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/tools/DockerCheckerTest.java
@@ -1,0 +1,131 @@
+package dev.buildcli.core.actions.tools;
+
+import dev.buildcli.core.actions.commandline.DockerProcess;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class DockerCheckerTest {
+  
+  private DockerChecker dockerChecker= new DockerChecker();
+
+  @Test
+  void testName() {
+    String result = dockerChecker.name();
+    String expected = "Docker";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testIsInstalled_WhenDockerIsInstalled_ShouldReturnTrue() {
+    DockerProcess mockProcess = mock(DockerProcess.class);
+    when(mockProcess.run()).thenReturn(0);
+
+    try (var mockedStatic = mockStatic(DockerProcess.class)) {
+      mockedStatic.when(DockerProcess::createGetVersionProcess).thenReturn(mockProcess);
+      assertTrue(dockerChecker.isInstalled());
+    }
+  }
+
+   @Test
+  void testIsInstalled_WhenDockerIsNotInstalled_ShouldReturnFalse() {
+    DockerProcess mockProcess = mock(DockerProcess.class);
+    when(mockProcess.run()).thenReturn(1);
+
+     try (var mockedStatic = mockStatic(DockerProcess.class)) {
+       mockedStatic.when(DockerProcess::createGetVersionProcess).thenReturn(mockProcess);
+      assertFalse(dockerChecker.isInstalled());
+    }
+  }
+
+  @Test
+  void testIsRunning_WhenDockerIsNotRunning_ShouldReturnFalse() {
+    DockerProcess mockProcess = mock(DockerProcess.class);
+    when(mockProcess.run()).thenReturn(1);
+
+    try (var mockedStatic = mockStatic(DockerProcess.class)) {
+      mockedStatic.when(DockerProcess::createInfoProcess).thenReturn(mockProcess);
+      assertFalse(dockerChecker.isRunning());
+    }
+  }
+
+  @Test
+  void testIsRunning_WhenDockerIsRunning_ShouldReturnTrue() {
+    DockerProcess mockProcess = mock(DockerProcess.class);
+    when(mockProcess.run()).thenReturn(0);
+
+    try (var mockedStatic = mockStatic(DockerProcess.class)) {
+      mockedStatic.when(DockerProcess::createInfoProcess).thenReturn(mockProcess);
+      assertTrue(dockerChecker.isRunning());
+    }
+  }
+
+  @Test
+  void testVersion_WhenDockerIsInstalled_ShouldReturnVersion() {
+    DockerProcess mockProcess = mock(DockerProcess.class);
+    when(mockProcess.run()).thenReturn(0);
+    when(mockProcess.output()).thenReturn(Collections.singletonList("Docker version 20.10.6, build 370c289"));
+
+    try (var mockedStatic = mockStatic(DockerProcess.class)) {
+      mockedStatic.when(DockerProcess::createGetVersionProcess).thenReturn(mockProcess);
+      String result = dockerChecker.version();
+      String expected = "20.10.6";
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  void testVersion_WhenDockerIsInstalled_ButOutputIsMalformed_ShouldReturnNA() {
+    DockerProcess mockProcess = mock(DockerProcess.class);
+    when(mockProcess.run()).thenReturn(1);
+    when(mockProcess.output()).thenReturn(Collections.singletonList("some random text"));
+
+    try (var mockedStatic = mockStatic(DockerProcess.class)) {
+      mockedStatic.when(DockerProcess::createGetVersionProcess).thenReturn(mockProcess);
+      String result = dockerChecker.version();
+      String expected = "N/A";
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  void testVersion_WhenDockerIsNotInstalled_ShouldReturnNA() {
+    DockerProcess mockProcess = mock(DockerProcess.class);
+    when(mockProcess.run()).thenReturn(1);
+    when(mockProcess.output()).thenReturn(Collections.emptyList());
+
+    try (var mockedStatic = mockStatic(DockerProcess.class)) {
+      mockedStatic.when(DockerProcess::createGetVersionProcess).thenReturn(mockProcess);
+      String result = dockerChecker.version();
+      String expected = "N/A";
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  void testInstall_Instructions() {
+    String result = dockerChecker.installInstructions();
+    String expected = "Install Docker: https://docs.docker.com/get-docker/";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFixIssue() {
+    var standardOut = System.out;
+    try {
+      var outputStream = new java.io.ByteArrayOutputStream();
+      System.setOut(new java.io.PrintStream(outputStream));
+
+      dockerChecker.fixIssue();
+      String content = "Fixing Docker issues is not automated. Please ensure Docker is installed and running.";
+
+      String output = outputStream.toString().trim();
+      assertEquals(content, output);
+    }finally {
+      System.setOut(standardOut);
+    }
+  }
+}


### PR DESCRIPTION
## Description  
This PR adds unit tests for the `DockerChecker` class.  

## Related Issues  
- **Unit Tests: DockerChecker.java** [#358 ](https://github.com/BuildCLI/BuildCLI/issues/358)  

## Changes  
- Added unit tests for the `DockerChecker` class.  
- Covered checks for Docker installation status.  
- Implemented tests to retrieve Docker version when installed and return "N/A" when not installed or output is malformed.  
- Verified that install instructions URL is returned correctly.  

## Testing  
The following unit tests were implemented:  

- [x] **`testName()`**: Verifies the tool name is correctly returned as "Docker".  
- [x] **`testIsInstalled_WhenDockerIsInstalled_ShouldReturnTrue()`**: Validates Docker installation detection (exit code 0).  
- [x] **`testIsInstalled_WhenDockerIsNotInstalled_ShouldReturnFalse()`**: Validates Docker absence detection (exit code 1).  
- [x] **`testIsRunning_WhenDockerIsRunning_ShouldReturnTrue()`**: Verifies Docker is running (exit code 0).  
- [x] **`testIsRunning_WhenDockerIsNotRunning_ShouldReturnFalse()`**: Verifies Docker is not running (exit code 1).  
- [x] **`testVersion_WhenDockerIsInstalled_ShouldReturnVersion()`**: Extracts version from valid Docker output (e.g., "20.10.6").  
- [x] **`testVersion_WhenDockerIsInstalled_ButOutputIsMalformed_ShouldReturnNA()`**: Returns "N/A" for unparseable version output.  
- [x] **`testVersion_WhenDockerIsNotInstalled_ShouldReturnNA()`**: Returns "N/A" when Docker is not installed.  
- [x] **`testInstall_Instructions()`**: Confirms installation URL matches "https://docs.docker.com/get-docker/".  
- [x] **`testFixIssue()`**: Ensures the message is printed when Docker issues are fixed manually.  

## Checklist  
- [x] My code follows the project's code style.  
- [x] I have run tests to confirm my changes do not break existing functionality.
