### PR TITLE
test: add unit test for ToolCheckers class

### DIFF
--- a/core/src/test/java/dev/buildcli/core/actions/tools/ToolCheckersTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/tools/ToolCheckersTest.java
@@ -1,0 +1,21 @@
+package dev.buildcli.core.actions.tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ToolCheckersTest {
+
+  @Test
+  void testAll_ReturnsAllToolCheckers() {
+    List<ToolChecker> toolCheckerList = ToolCheckers.all();
+
+    assertEquals(4, toolCheckerList.size());
+    assertEquals(JDKChecker.class, toolCheckerList.get(0).getClass());
+    assertEquals(MavenChecker.class, toolCheckerList.get(1).getClass());
+    assertEquals(GradleChecker.class, toolCheckerList.get(2).getClass());
+    assertEquals(DockerChecker.class, toolCheckerList.get(3).getClass());
+  }
+}


### PR DESCRIPTION
## Description  
This PR adds unit tests for the `ToolCheckers` class.  

## Related Issues  
- **Unit Tests: ToolCheckers.java** [#356](https://github.com/BuildCLI/BuildCLI/issues/356)  

## Changes  
- Added unit tests for the `ToolCheckers` class.  
- Covered the `all()` method to validate the list of `ToolChecker` instances.  
- Implemented checks to verify that the list returned contains `JDKChecker`, `MavenChecker`, `GradleChecker`, and `DockerChecker` in the correct order.  

## Testing  
The following unit tests were implemented:  

- [x] **`TestAll_ReturnAllTollCheckers()`**: Verifies that the `all()` method returns a list of size 4 with the correct `ToolChecker` subclasses in order: `JDKChecker`, `MavenChecker`, `GradleChecker`, and `DockerChecker`.

## Checklist  
- [x] My code follows the project's code style.  
- [x] I have run tests to confirm my changes do not break existing functionality.
