### PR TITLE
test: Add unit tests for JDKChecker class

### DIFF
--- a/core/src/test/java/dev/buildcli/core/actions/tools/JDKCheckerTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/tools/JDKCheckerTest.java
@@ -1,0 +1,108 @@
+package dev.buildcli.core.actions.tools;
+
+import dev.buildcli.core.actions.commandline.JavaProcess;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class JDKCheckerTest {
+  private JDKChecker jdkChecker = new JDKChecker();
+
+  @Test
+  void testName() {
+    String result = jdkChecker.name();
+    String expected = "JDK";
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testIsInstalled_WhenJDKIsInstalled_ShouldReturnTrue() {
+    JavaProcess mockProcess = mock(JavaProcess.class);
+    when(mockProcess.run()).thenReturn(0);
+
+    try (var mockedStatic = mockStatic(JavaProcess.class)) {
+      mockedStatic.when(JavaProcess::createGetVersionProcess).thenReturn(mockProcess);
+      assertTrue(jdkChecker.isInstalled());
+    }
+  }
+
+  @Test
+  void testIsInstalled_WhenJDKIsNotInstalled_ShouldReturnFalse() {
+    JavaProcess mockProcess = mock(JavaProcess.class);
+    when(mockProcess.run()).thenReturn(1);
+
+    try (var mockedStatic = mockStatic(JavaProcess.class)) {
+      mockedStatic.when(JavaProcess::createGetVersionProcess).thenReturn(mockProcess);
+      assertFalse(jdkChecker.isInstalled());
+    }
+  }
+
+  @Test
+  void testVersion_WhenJDKIsInstalled_ShouldReturnVersion() {
+    JavaProcess mockProcess = mock(JavaProcess.class);
+    when(mockProcess.run()).thenReturn(0);
+    when(mockProcess.output()).thenReturn(Collections.singletonList("openjdk 21.0.6 2025-01-21"));
+
+    try (var mockedStatic = mockStatic(JavaProcess.class)) {
+      mockedStatic.when(JavaProcess::createGetVersionProcess).thenReturn(mockProcess);
+      String result = jdkChecker.version();
+      String expected = "21.0.6";
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  void testVersion_WhenJDKIsInstalled_ButOutputIsMalformed_ShouldReturnNA() {
+    JavaProcess mockProcess = mock(JavaProcess.class);
+    when(mockProcess.run()).thenReturn(1);
+    when(mockProcess.output()).thenReturn(Collections.singletonList("some random text"));
+
+    try (var mockedStatic = mockStatic(JavaProcess.class)) {
+      mockedStatic.when(JavaProcess::createGetVersionProcess).thenReturn(mockProcess);
+      String result = jdkChecker.version();
+      String expected = "N/A";
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  void testVersion_WhenJDKIsNotInstalled_ShouldReturnNA() {
+    JavaProcess mockProcess = mock(JavaProcess.class);
+    when(mockProcess.run()).thenReturn(1);
+    when(mockProcess.output()).thenReturn(Collections.emptyList());
+
+    try (var mockedStatic = mockStatic(JavaProcess.class)) {
+      mockedStatic.when(JavaProcess::createGetVersionProcess).thenReturn(mockProcess);
+      String result = jdkChecker.version();
+      String expected = "N/A";
+      assertEquals(expected, result);
+    }
+  }
+
+  @Test
+  void testInstall_Instructions() {
+    String result = jdkChecker.installInstructions();
+    String expected = "Install JDK: https://www.oracle.com/java/technologies/javase-downloads.html";;
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testFixIssue() {
+    var standardOut = System.out;
+    try {
+      var outputStream = new java.io.ByteArrayOutputStream();
+      System.setOut(new java.io.PrintStream(outputStream));
+
+      jdkChecker.fixIssue();
+      String content = "Fixing JDK issues is not automated. Follow the installation instructions.";
+
+      String output = outputStream.toString().trim();
+      assertEquals(content, output);
+    }finally {
+      System.setOut(standardOut);
+    }
+  }
+}


### PR DESCRIPTION
## Description  
This PR adds unit tests for the `JDKChecker` class.  

## Related Issues  
- **Unit Tests: JDKChecker.java** [#357 ](https://github.com/BuildCLI/BuildCLI/issues/357)  

## Changes  
- Added unit tests for the `JDKChecker` class.  
- Covered checks for JDK installation status.  
- Implemented tests to retrieve JDK version when installed and return "N/A" when not installed or output is malformed.  
- Verified that the installation instructions URL is returned correctly.  
- Implemented a test to ensure the correct message is printed when fixing JDK issues.  

## Testing  
The following unit tests were implemented:  

- [x] **`testName()`**: Verifies the tool name is correctly returned as "JDK".  
- [x] **`testIsInstalled_WhenJDKIsInstalled_ShouldReturnTrue()`**: Validates JDK installation detection (exit code 0).  
- [x] **`testIsInstalled_WhenJDKIsNotInstalled_ShouldReturnFalse()`**: Validates JDK absence detection (exit code 1).  
- [x] **`testVersion_WhenJDKIsInstalled_ShouldReturnVersion()`**: Extracts version from valid JDK output (e.g., "openjdk 21.0.6").  
- [x] **`testVersion_WhenJDKIsInstalled_ButOutputIsMalformed_ShouldReturnNA()`**: Returns "N/A" for unparseable version output.  
- [x] **`testVersion_WhenJDKIsNotInstalled_ShouldReturnNA()`**: Returns "N/A" when JDK is not installed.  
- [x] **`testInstall_Instructions()`**: Confirms installation URL matches "https://www.oracle.com/java/technologies/javase-downloads.html".  
- [x] **`testFixIssue()`**: Ensures the message is printed when JDK issues are fixed manually.  

## Checklist  
- [x] My code follows the project's code style.  
- [x] I have run tests to confirm my changes do not break existing functionality.
