### PR TITLE
Add unit tests for DockerProcess methods

### DIFF
--- a/core/src/test/java/dev/buildcli/core/actions/commandline/DockerProcessTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/commandline/DockerProcessTest.java
@@ -1,0 +1,87 @@
+package dev.buildcli.core.actions.commandline;
+
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DockerProcessTest {
+
+  private String tag = "dockerCompose";
+  private String fileName = "dockerFile";
+
+  @Test
+  void testCreateBuildProcess_withGivenTagParams() {
+    DockerProcess dockerProcess = DockerProcess.createBuildProcess(tag);
+
+    assertFalse(dockerProcess.commands.isEmpty());
+    assertEquals("docker", dockerProcess.commands.get(0));
+    assertEquals("build", dockerProcess.commands.get(1));
+    assertEquals("-t", dockerProcess.commands.get(2));
+    assertEquals(tag, dockerProcess.commands.get(3));
+    assertEquals(".", dockerProcess.commands.get(4));
+    assertEquals(5, dockerProcess.commands.size());
+  }
+
+  @Test
+  void testCreateBuildProcess_withTagAndFileName() {
+    DockerProcess dockerProcess = DockerProcess.createBuildProcess(tag, fileName);
+
+    assertFalse(dockerProcess.commands.isEmpty());
+    assertEquals("docker", dockerProcess.commands.get(0));
+    assertEquals("build", dockerProcess.commands.get(1));
+    assertEquals("-t", dockerProcess.commands.get(2));
+    assertEquals(tag, dockerProcess.commands.get(3));
+    assertEquals("-f", dockerProcess.commands.get(4));
+    assertEquals(fileName, dockerProcess.commands.get(5));
+    assertEquals(6, dockerProcess.commands.size());
+  }
+
+  @Test
+  void testCreateBuildProcessWithoutAdditionalParams() {
+    DockerProcess dockerProcess = DockerProcess.createProcess();
+    assertEquals(DockerProcess.class, dockerProcess.getClass());
+    assertFalse(dockerProcess.commands.isEmpty());
+    assertEquals("docker", dockerProcess.commands.get(0));
+    assertFalse(dockerProcess.commands.contains("build"));
+  }
+
+  @Test
+  void testCreateProcess_withSpecificParams() {
+    DockerProcess dockerProcess = DockerProcess.createProcess("clean", "build", "-f");
+
+    assertFalse(dockerProcess.commands.isEmpty());
+    assertEquals("docker", dockerProcess.commands.get(0));
+    assertEquals("clean", dockerProcess.commands.get(1));
+    assertEquals("build", dockerProcess.commands.get(2));
+    assertEquals("-f", dockerProcess.commands.get(3));
+  }
+
+  @Test
+  void testCreateRunProcessor() {
+    DockerProcess dockerProcess = DockerProcess.createRunProcess(tag);
+
+    assertFalse(dockerProcess.commands.isEmpty());
+    assertEquals("docker", dockerProcess.commands.get(0));
+    assertEquals("run", dockerProcess.commands.get(1));
+    assertEquals("-p", dockerProcess.commands.get(2));
+    assertEquals("8080:8080", dockerProcess.commands.get(3));
+    assertEquals(tag, dockerProcess.commands.get(4));
+  }
+
+  @Test
+  void testCreateGetVersionProcess() {
+    DockerProcess dockerProcess = DockerProcess.createGetVersionProcess();
+    assertFalse(dockerProcess.commands.isEmpty());
+    assertEquals("docker", dockerProcess.commands.get(0));
+    assertEquals("-v", dockerProcess.commands.get(1));
+  }
+
+  @Test
+  void testCreateInfoProcess() {
+    DockerProcess dockerProcess = DockerProcess.createInfoProcess();
+    assertFalse(dockerProcess.commands.isEmpty());
+    assertEquals("docker", dockerProcess.commands.get(0));
+    assertEquals("info", dockerProcess.commands.get(1));
+  }
+}


### PR DESCRIPTION
## Description  
This PR adds unit tests for the `DockerProcess` class.  

## Related Issues  
- **Unit Tests: DockerProcess.java** [#364](https://github.com/BuildCLI/BuildCLI/issues/364)  

## Changes  
- Added unit tests for the `DockerProcess` class.  
- Covered tests for creating build, run, and general Docker processes with and without parameters.  
- Verified that the correct version and info commands are created.  

## Testing  
The following unit tests were implemented:  

- [x] **`testCreateBuildProcess_withGivenTagParams()`**: Verifies that the build process is correctly created with a given tag and default parameters.
- [x] **`testCreateBuildProcess_withTagAndFileName()`**: Verifies that the build process is correctly created with a given tag and a specified file name.
- [x] **`testCreateBuildProcessWithoutAdditionalParams()`**: Verifies that the Docker process is correctly created without additional parameters and without the build command.
- [x] **`testCreateProcess_withSpecificParams()`**: Validates the creation of a Docker process with specific tasks and parameters.
- [x] **`testCreateRunProcessor()`**: Confirms that the run processor is created correctly with port mapping and the given tag.
- [x] **`testCreateGetVersionProcess()`**: Verifies that the version command is correctly created for the Docker process.
- [x] **`testCreateInfoProcess()`**: Verifies that the info command is correctly created for the Docker process.

## Checklist  
- [x] My code follows the project's code style.  
- [x] I have run tests to confirm my changes do not break existing functionality.
