### PR TITLE
Add unit tests for MavenProcess

### DIFF
--- a/core/src/test/java/dev/buildcli/core/actions/commandline/MavenProcessTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/commandline/MavenProcessTest.java
@@ -1,0 +1,121 @@
+package dev.buildcli.core.actions.commandline;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public class MavenProcessTest {
+
+  private Path tempDir;
+  private MavenProcess mavenProcess;
+
+  @BeforeEach
+  void beforeEach() throws IOException {
+    tempDir = Files.createTempDirectory("output_dir");
+    Files.createDirectories(tempDir);
+  }
+
+  @AfterEach
+  void cleanup() throws IOException {
+    Files.walk(tempDir)
+        .sorted(Comparator.reverseOrder())
+        .forEach(p -> {
+          try {
+            Files.deleteIfExists(p);
+          } catch (IOException e) {
+            throw new RuntimeException("Erro ao excluir o arquivo: " + p, e);
+          }
+        });
+  }
+
+  @Test
+  void testCreateProcessor() {
+    mavenProcess = MavenProcess.createProcessor();
+    assertEquals(MavenProcess.class, mavenProcess.getClass());
+    assertFalse(mavenProcess.commands.isEmpty());
+    assertEquals("mvn", mavenProcess.commands.get(0));
+    assertFalse(mavenProcess.commands.contains("build"));
+  }
+
+  @Test
+  void testCreateProcessor_withGivenParams() {
+    mavenProcess = MavenProcess.createProcessor("clean", "build", "-f");
+
+    assertFalse(mavenProcess.commands.isEmpty());
+    assertEquals("mvn", mavenProcess.commands.get(0));
+    assertEquals("clean", mavenProcess.commands.get(1));
+    assertEquals("build", mavenProcess.commands.get(2));
+    assertEquals("-f", mavenProcess.commands.get(3));
+  }
+
+  @Test
+  void testCreatePackageProcessor_withValidDirectory() {
+    var standardOut = System.out;
+    try {
+      var outputStream = new java.io.ByteArrayOutputStream();
+      System.setOut(new PrintStream(outputStream));
+      mavenProcess = MavenProcess.createPackageProcessor(tempDir.toFile());
+
+      String expectedLogMessage = "Running maven package command: mvn clean package -f " + tempDir.toString();
+      assertTrue(outputStream.toString().contains(expectedLogMessage));
+      assertFalse(mavenProcess.commands.isEmpty());
+      assertEquals("mvn", mavenProcess.commands.get(0));
+      assertEquals("clean", mavenProcess.commands.get(1));
+      assertEquals("package", mavenProcess.commands.get(2));
+      assertEquals("-f", mavenProcess.commands.get(3));
+      assertEquals(tempDir.toString(), mavenProcess.commands.get(4));
+    } finally {
+      System.setOut(standardOut);
+    }
+  }
+
+  @Test
+  void testCreateCompileProcessor_withValidDirectory() {
+    var standardOut = System.out;
+    try {
+      var outputStream = new java.io.ByteArrayOutputStream();
+      System.setOut(new PrintStream(outputStream));
+      mavenProcess = MavenProcess.createCompileProcessor(tempDir.toFile());
+
+      String expectedLogMessage = "Running maven compile command: mvn compile -f " + tempDir.toString();
+      assertTrue(outputStream.toString().contains(expectedLogMessage));
+      assertFalse(mavenProcess.commands.isEmpty());
+      assertEquals("mvn", mavenProcess.commands.get(0));
+      assertEquals("clean", mavenProcess.commands.get(1));
+      assertEquals("compile", mavenProcess.commands.get(2));
+      assertEquals("-f", mavenProcess.commands.get(3));
+      assertEquals(tempDir.toString(), mavenProcess.commands.get(4));
+    } finally {
+      System.setOut(standardOut);
+    }
+  }
+
+  @Test
+  void testCreateGetVersionProcess() {
+    mavenProcess = MavenProcess.createGetVersionProcessor();
+    assertFalse(mavenProcess.commands.isEmpty());
+    assertEquals("mvn", mavenProcess.commands.get(0));
+    assertEquals("-v", mavenProcess.commands.get(1));
+  }
+
+  @Test
+  void testRunCommands() {
+    mavenProcess = MavenProcess.createGetVersionProcessor();
+    int exitCode = mavenProcess.run();
+    List<String> output = mavenProcess.output();
+
+    assertEquals(0, exitCode);
+    assertFalse(output.isEmpty());
+    assertTrue(output.get(0).contains("Apache Maven"));
+  }
+}


### PR DESCRIPTION
## Description  
This PR adds unit tests for the `MavenProcess` class.  

## Related Issues  
- **Unit Tests: MavenProcess.java** [#360](https://github.com/BuildCLI/BuildCLI/issues/360)  

## Changes  
- Added unit tests for the `MavenProcess` class.  
- Covered tests for creating processors with and without parameters.  
- Implemented tests for package and compile process creation with valid directories.  
- Verified that the correct version command is created.  

## Testing  
The following unit tests were implemented:  

- [x] **`testCreateProcessor()`**: Verifies that the default Maven process is correctly created.  
- [x] **`testCreateProcessor_withGivenParams()`**: Validates the creation of a Maven process with specific tasks and parameters.  
- [x] **`testCreatePackageProcessor_withValidDirectory()`**: Confirms that the package processor is created correctly and logs the appropriate message.  
- [x] **`testCreateCompileProcessor_withValidDirectory()`**: Ensures the compile processor is created correctly and logs the appropriate message.  
- [x] **`testCreateGetVersionProcess()`**: Verifies that the version command is correctly created for the Maven process.  

## Checklist  
- [x] My code follows the project's code style.  
- [x] I have run tests to confirm my changes do not break existing functionality.
