### PR TITLE
Fix/run project

### DIFF
--- a/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
@@ -70,7 +70,7 @@ public class InitCommand implements BuildCLICommand {
       try (FileWriter writer = new FileWriter(javaClass)) {
         writer.write("""
                 package %s;
-            
+
                 public class Main {
                     public static void main(String[] args) {
                         System.out.println("Hello, World!");
@@ -82,7 +82,7 @@ public class InitCommand implements BuildCLICommand {
     }
   }
 
-  private void createPomFile(String projectName) throws IOException {
+  private void createPomFile(String projectName, String basePackage) throws IOException {
     File pomFile = new File("pom.xml");
     if (pomFile.createNewFile()) {
       try (FileWriter writer = new FileWriter(pomFile)) {
@@ -91,17 +91,17 @@ public class InitCommand implements BuildCLICommand {
                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://www.apache.org/xsd/maven-4.0.0.xsd">
                     <modelVersion>4.0.0</modelVersion>
-            
-                    <groupId>org.%s</groupId>
+
+                    <groupId>%s</groupId>
                     <artifactId>%s</artifactId>
                     <version>1.0-SNAPSHOT</version>
-            
+
                     <properties>
                         <maven.compiler.source>%s</maven.compiler.source>
                         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
                         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
                     </properties>
-            
+
                     <dependencies>
                         <dependency>
                             <groupId>org.junit.jupiter</groupId>
@@ -110,7 +110,7 @@ public class InitCommand implements BuildCLICommand {
                             <scope>test</scope>
                         </dependency>
                     </dependencies>
-            
+
                     <build>
                         <plugins>
                             <plugin>
@@ -129,7 +129,7 @@ public class InitCommand implements BuildCLICommand {
                                 <configuration>
                                     <archive>
                                         <manifest>
-                                            <mainClass>org.%s.Main</mainClass>
+                                            <mainClass>%s.Main</mainClass>
                                         </manifest>
                                     </archive>
                                 </configuration>
@@ -137,7 +137,7 @@ public class InitCommand implements BuildCLICommand {
                         </plugins>
                     </build>
                 </project>
-            """.formatted(projectName.toLowerCase(), projectName, jdkVersion, projectName.toLowerCase()));
+            """.formatted(basePackage, projectName, jdkVersion, basePackage));
       }
       SystemOutLogger.log("pom.xml file created with default configuration.");
     }
@@ -171,7 +171,7 @@ public class InitCommand implements BuildCLICommand {
       try {
         createReadme(projectName);
         createMainClass(basePackage);
-        createPomFile(projectName);
+        createPomFile(projectName, basePackage);
       } catch (IOException e) {
         throw new CommandExecutorRuntimeException(e);
       }


### PR DESCRIPTION
## Description
This PR fixes an issue in the `init` command where the `groupId` and `mainClass` in the generated `pom.xml` would incorrectly prepend `org.` to the user-provided base package, even when the package already included the `org.` prefix. This led to invalid class paths like `org.org.myproject.Main`.

## Related Issues
Fixes #536 

## Changes
- [x] Removed hardcoded `org.` prefix from `groupId` and `mainClass` generation in `createPomFile` method
- [x] Ensured `basePackage` is used as-is when formatting these values

## Testing
- Created a project using `buildcli project init` with the base package `org.myproject`
- Verified that the generated `pom.xml` correctly sets:
  - `<groupId>org.myproject</groupId>`
  - `<mainClass>org.myproject.Main</mainClass>`
- Successfully ran the project using `buildcli run` without encountering `ClassNotFoundException`

### Checklist
- [x] My code follows the code style of this project
- [x] I have run tests to check that my changes do not break existing code

## Additional Notes
This fix improves the developer experience by ensuring consistency and correctness when the user provides a fully qualified base package during project initialization.
