### PR TITLE
fix(tests) Fix failing tests on windows 10 and correcting junit version

### DIFF
--- a/cli/src/test/java/dev/buildcli/cli/core/AboutServiceTest.java
+++ b/cli/src/test/java/dev/buildcli/cli/core/AboutServiceTest.java
@@ -8,7 +8,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,7 +41,11 @@ class AboutServiceTest {
 
                 contributor1, contributor2""";
 
-            assertEquals(expected, outputStream.toString().trim());
+            List<String> expectedLines = expected.lines().toList();
+            List<String> actualLines = outputStream.toString().lines().toList();
+
+            assertLinesMatch(expectedLines, actualLines);
+
         } finally {
             System.setOut(standardOut);
         }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/test/java/dev/buildcli/core/actions/commandline/GradleProcessTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/commandline/GradleProcessTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 
+import static dev.buildcli.core.constants.GradleConstants.GRADLE_CMD;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GradleProcessTest {
@@ -40,7 +41,7 @@ public class GradleProcessTest {
     GradleProcess gradleProcess = GradleProcess.createProcessor();
     assertEquals(GradleProcess.class, gradleProcess.getClass());
     assertFalse(gradleProcess.commands.isEmpty());
-    assertEquals("gradle", gradleProcess.commands.get(0));
+    assertEquals(GRADLE_CMD, gradleProcess.commands.get(0));
     assertFalse(gradleProcess.commands.contains("build"));
   }
 
@@ -49,7 +50,7 @@ public class GradleProcessTest {
     GradleProcess gradleProcess = GradleProcess.createProcessor("clean", "build", "-f");
 
     assertFalse(gradleProcess.commands.isEmpty());
-    assertEquals("gradle", gradleProcess.commands.get(0));
+    assertEquals(GRADLE_CMD, gradleProcess.commands.get(0));
     assertEquals("clean", gradleProcess.commands.get(1));
     assertEquals("build", gradleProcess.commands.get(2));
     assertEquals("-f", gradleProcess.commands.get(3));
@@ -66,7 +67,7 @@ public class GradleProcessTest {
       String expectedLogMessage = "Running gradle package command: gradle clean build -f " + tempDir.toString();
       assertTrue(outputStream.toString().contains(expectedLogMessage));
       assertFalse(gradleProcess.commands.isEmpty());
-      assertEquals("gradle", gradleProcess.commands.get(0));
+      assertEquals(GRADLE_CMD, gradleProcess.commands.get(0));
       assertEquals("clean", gradleProcess.commands.get(1));
       assertEquals("build", gradleProcess.commands.get(2));
       assertEquals("-f", gradleProcess.commands.get(3));
@@ -86,7 +87,7 @@ public class GradleProcessTest {
       String expectedLogMessage = "Running gradle compile command: gradle clean classes -f " + tempDir.toString();
       assertTrue(outputStream.toString().contains(expectedLogMessage));
       assertFalse(gradleProcess.commands.isEmpty());
-      assertEquals("gradle", gradleProcess.commands.get(0));
+      assertEquals(GRADLE_CMD, gradleProcess.commands.get(0));
       assertEquals("clean", gradleProcess.commands.get(1));
       assertEquals("classes", gradleProcess.commands.get(2));
       assertEquals("-f", gradleProcess.commands.get(3));
@@ -99,7 +100,7 @@ public class GradleProcessTest {
   void testCreateGetVersionProcess() {
     GradleProcess gradleProcess = GradleProcess.createGetVersionProcess();
     assertFalse(gradleProcess.commands.isEmpty());
-    assertEquals("gradle", gradleProcess.commands.get(0));
+    assertEquals(GRADLE_CMD, gradleProcess.commands.get(0));
     assertEquals("--version", gradleProcess.commands.get(1));
   }
 }

--- a/core/src/test/java/dev/buildcli/core/actions/commandline/MavenProcessTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/commandline/MavenProcessTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
 
+import static dev.buildcli.core.constants.MavenConstants.MAVEN_CMD;
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -43,7 +44,7 @@ public class MavenProcessTest {
     mavenProcess = MavenProcess.createProcessor();
     assertEquals(MavenProcess.class, mavenProcess.getClass());
     assertFalse(mavenProcess.commands.isEmpty());
-    assertEquals("mvn", mavenProcess.commands.get(0));
+    assertEquals(MAVEN_CMD, mavenProcess.commands.get(0));
     assertFalse(mavenProcess.commands.contains("build"));
   }
 
@@ -52,7 +53,7 @@ public class MavenProcessTest {
     mavenProcess = MavenProcess.createProcessor("clean", "build", "-f");
 
     assertFalse(mavenProcess.commands.isEmpty());
-    assertEquals("mvn", mavenProcess.commands.get(0));
+    assertEquals(MAVEN_CMD, mavenProcess.commands.get(0));
     assertEquals("clean", mavenProcess.commands.get(1));
     assertEquals("build", mavenProcess.commands.get(2));
     assertEquals("-f", mavenProcess.commands.get(3));
@@ -69,7 +70,7 @@ public class MavenProcessTest {
       String expectedLogMessage = "Running maven package command: mvn clean package -f " + tempDir.toString();
       assertTrue(outputStream.toString().contains(expectedLogMessage));
       assertFalse(mavenProcess.commands.isEmpty());
-      assertEquals("mvn", mavenProcess.commands.get(0));
+      assertEquals(MAVEN_CMD, mavenProcess.commands.get(0));
       assertEquals("clean", mavenProcess.commands.get(1));
       assertEquals("package", mavenProcess.commands.get(2));
       assertEquals("-f", mavenProcess.commands.get(3));
@@ -90,7 +91,7 @@ public class MavenProcessTest {
       String expectedLogMessage = "Running maven compile command: mvn compile -f " + tempDir.toString();
       assertTrue(outputStream.toString().contains(expectedLogMessage));
       assertFalse(mavenProcess.commands.isEmpty());
-      assertEquals("mvn", mavenProcess.commands.get(0));
+      assertEquals(MAVEN_CMD, mavenProcess.commands.get(0));
       assertEquals("clean", mavenProcess.commands.get(1));
       assertEquals("compile", mavenProcess.commands.get(2));
       assertEquals("-f", mavenProcess.commands.get(3));
@@ -104,7 +105,7 @@ public class MavenProcessTest {
   void testCreateGetVersionProcess() {
     mavenProcess = MavenProcess.createGetVersionProcessor();
     assertFalse(mavenProcess.commands.isEmpty());
-    assertEquals("mvn", mavenProcess.commands.get(0));
+    assertEquals(MAVEN_CMD, mavenProcess.commands.get(0));
     assertEquals("-v", mavenProcess.commands.get(1));
   }
 

--- a/core/src/test/java/dev/buildcli/core/utils/OSTest.java
+++ b/core/src/test/java/dev/buildcli/core/utils/OSTest.java
@@ -181,11 +181,10 @@ class OSTest {
   @Test
   void shouldNotExecuteChmod_whenOSIsWindows() throws Exception {
     File ex = Files.createTempFile("test", "sh").toFile();
-    assertFalse(ex.canExecute());
     try {
       System.setProperty("os.name", "Windows 10");
       OS.chmodX(ex.toString());
-      assertFalse(ex.canExecute());
+      verify(mockRuntimeCommandExecutor, times(0)).execute(any());
     } finally {
       System.setProperty("os.name", OS_NAME);
     }
@@ -207,6 +206,7 @@ class OSTest {
 
   @Test
   void shouldNotThrowException_whenChmodXCommandFails() throws Exception {
+    System.setProperty("os.name", "Linux");
     doThrow(new RuntimeException("Exec falhou")).when(mockRuntimeCommandExecutor).execute(any());
     OS.setCommandExecutor(mockRuntimeCommandExecutor);
     assertDoesNotThrow(() -> OS.chmodX("testFile"));

--- a/core/src/test/resources/pom-core-test/pom.xml
+++ b/core/src/test/resources/pom-core-test/pom.xml
@@ -19,7 +19,6 @@
 			<dependency>
 				<groupId>org.junit</groupId>
 				<artifactId>junit-bom</artifactId>
-				<version>5.13.0-M2</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
This PR resolves all test failures to ensure mvn clean install passes successfully on windows OS.

key improvements include:

• AboutServiceTest.java proper handling different newline characters (**\n** vs **\r\n**)
• junit-jupiter-api using default version coming from parent/dependency management
• Using Gradle/Maven Constants to use the proper value for maven cmd (mvn/gradle vs mvn.bat/gradle.bat on windows)
• File.canExecute method not reliable, test was failing, now we actually verify that the command isn't executed.
• In shouldNotThrowException_whenChmodXCommandFails if System.setProperty("os.name", "Linux"); not set, test fails on windows.

Before:
![image](https://github.com/user-attachments/assets/0db2ca9e-abb0-431a-ab66-b64a751c686c)


After:
![image](https://github.com/user-attachments/assets/e59968a9-0a8c-449b-8ef3-32fb8b3ad574)
