### PR TITLE
Refactor/read manifest logic

### DIFF
--- a/cli/src/test/java/dev/buildcli/cli/core/DefaultManifestReaderTest.java
+++ b/cli/src/test/java/dev/buildcli/cli/core/DefaultManifestReaderTest.java
@@ -1,0 +1,81 @@
+package dev.buildcli.cli.core;
+
+import dev.buildcli.core.utils.DefaultManifestReader;
+import dev.buildcli.core.utils.ManifestReader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.jar.Manifest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DefaultManifestReaderTest {
+
+    @Test
+    @DisplayName("Read valid manifest")
+    void testReadManifest_success() {
+        // given
+        String[] manifestContents = {
+                "Build-Directory: /build/test/output\n",
+                "Manifest-Version: 1.0\n" + "Build-Directory: /build/test/output\n",
+        };
+
+        for (String manifestContent : manifestContents) {
+            InputStream inputStream = new ByteArrayInputStream(manifestContent.getBytes());
+            ManifestReader reader = new DefaultManifestReader();
+
+            // when
+            Manifest manifest = reader.readManifest(inputStream);
+
+            // then
+            String value = manifest.getMainAttributes().getValue("Build-Directory");
+            assertEquals("/build/test/output", value, "input [" + manifestContent + "]");
+        }
+    }
+
+    @Test
+    @DisplayName("Read manifest without 'Build-Directory'")
+    void testReadManifest_success_empty() {
+        // given
+        String[] manifestContents = {
+                "Manifest-Version: 1.0\n",
+        };
+
+        for (String manifestContent : manifestContents) {
+            InputStream inputStream = new ByteArrayInputStream(manifestContent.getBytes());
+            ManifestReader reader = new DefaultManifestReader();
+
+            // when
+            Manifest manifest = reader.readManifest(inputStream);
+
+            // then
+            String buildDirectory = manifest.getMainAttributes().getValue("Build-Directory");
+            assertEquals(null, buildDirectory, "input: [" + manifestContent + "]");
+        }
+    }
+
+    @Test
+    @DisplayName("Fail on invalid manifest")
+    void testReadManifest_fail_read() {
+        // given
+        String[] manifestContents = {
+                "Build-Directory\n",
+                "Build-Directory /build/test/output\n",
+                "Build-Directory:\n  continued-line-without-space",
+                "Build-Directory:\ncontinued"
+        };
+
+        for (String manifestContent : manifestContents) {
+            InputStream inputStream = new ByteArrayInputStream(manifestContent.getBytes());
+            ManifestReader reader = new DefaultManifestReader();
+
+            // when & then
+            assertThrows(RuntimeException.class, () -> {
+                reader.readManifest(inputStream);
+            }, "input: [" + manifestContent + "]");
+        }
+    }
+}

--- a/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
+++ b/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
@@ -177,8 +177,8 @@ public class BuildCLIService {
   }
 
   private static String readManifest(InputStream inputStream) {
-    try {
-      Manifest manifest = new Manifest(inputStream);
+      ManifestReader manifestReader = new DefaultManifestReader();
+      Manifest manifest = manifestReader.readManifest(inputStream);
       Attributes attributes = manifest.getMainAttributes();
       String buildDirectory = attributes.getValue("Build-Directory");
 
@@ -187,9 +187,6 @@ public class BuildCLIService {
       }
 
       return buildDirectory;
-    } catch (IOException e) {
-      throw new RuntimeException("Error while trying to read the content of the MANIFEST.MF file", e);
-    }
   }
 
 }

--- a/core/src/main/java/dev/buildcli/core/utils/DefaultManifestReader.java
+++ b/core/src/main/java/dev/buildcli/core/utils/DefaultManifestReader.java
@@ -1,0 +1,21 @@
+package dev.buildcli.core.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.Manifest;
+
+public class DefaultManifestReader implements ManifestReader {
+
+    @Override
+    public Manifest readManifest(InputStream inputStream) {
+        return readManifestWithThrows(inputStream);
+    }
+
+    private Manifest readManifestWithThrows(InputStream inputStream) {
+        try {
+            return new Manifest(inputStream);
+        } catch (IOException e) {
+            throw new RuntimeException("Error while trying to read the content of the MANIFEST.MF file", e);
+        }
+    }
+}

--- a/core/src/main/java/dev/buildcli/core/utils/ManifestReader.java
+++ b/core/src/main/java/dev/buildcli/core/utils/ManifestReader.java
@@ -1,0 +1,9 @@
+package dev.buildcli.core.utils;
+
+import java.io.InputStream;
+import java.util.jar.Manifest;
+
+public interface ManifestReader {
+
+    Manifest readManifest(InputStream inputStream);
+}


### PR DESCRIPTION
# Description
This PR prepares for the refactoring of `BuildCLIService` by extracting the manifest reading logic into a separate class.

# Related Issues
- Resolves: #494

# Changes
- Moves manifest parsing from `BuildCLIService` to `DefaultManifestReader`.
- Add unit tests for manifest reading logic.