### PR TITLE
test: add test cases for CommandExecutorRuntimeException

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,6 +19,18 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.12.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>info.picocli</groupId>
@@ -75,7 +87,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/test/java/dev/buildcli/core/exceptions/CommandExecutorRuntimeExceptionTest.java
+++ b/core/src/test/java/dev/buildcli/core/exceptions/CommandExecutorRuntimeExceptionTest.java
@@ -1,0 +1,64 @@
+package dev.buildcli.core.exceptions;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandExecutorRuntimeExceptionTest {
+
+    private static final String ERROR_MESSAGE = "Error message";
+    private static final String CAUSE = "Cause exception";
+
+    @Test
+    @DisplayName("Testa a CommandExecutorRuntimeException sem parâmetros")
+    public void testCommandExecutorRuntimeExceptionWithoutParams() {
+        CommandExecutorRuntimeException exception = new CommandExecutorRuntimeException();
+
+        assertNull(exception.getCause());
+        assertNull(exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("Testa a mensagem de CommandExecutorRuntimeException está correta")
+    public void testCommandExecutorRuntimeExceptionWithMessage() {
+        CommandExecutorRuntimeException exception = new CommandExecutorRuntimeException(ERROR_MESSAGE);
+
+        assertEquals(ERROR_MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("Testa a causa de CommandExecutorRuntimeException está correta")
+    public void testCommandExecutorRuntimeExceptionWithCause() {
+        Throwable cause_exception = new Throwable(CAUSE);
+
+        CommandExecutorRuntimeException exception = new CommandExecutorRuntimeException(cause_exception);
+
+        assertEquals(cause_exception, exception.getCause());
+    }
+
+    @Test
+    @DisplayName("Testa a causa e mensagem de CommandExecutorRuntimeException está correto")
+    public void testCommandExecutorRuntimeExceptionWithCauseAndMessage() {
+        Throwable cause_exception = new Throwable(CAUSE);
+
+        CommandExecutorRuntimeException exception = new CommandExecutorRuntimeException(ERROR_MESSAGE, cause_exception);
+
+        assertEquals(cause_exception, exception.getCause());
+        assertEquals(ERROR_MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("Testa a mensagem e a causa do construtor completo")
+    public void testCommandExecutorRuntimeExceptionWithAllParams() {
+        Throwable cause_exception = new Throwable(CAUSE);
+
+        CommandExecutorRuntimeException exception = new CommandExecutorRuntimeException(ERROR_MESSAGE,
+                cause_exception,
+                true,
+                true
+        );
+
+        assertEquals(cause_exception, exception.getCause());
+        assertEquals(ERROR_MESSAGE, exception.getMessage());
+    }
+}


### PR DESCRIPTION
## Description
This PR adds unit tests to verify CommandExecutorRuntimeException

## Related Issues
Unit Tests: CommandExecutorRuntimeException.java #436 

## Changes
Added unit tests for the CommandExecutorRuntimeException class.
Added dependencyManagementon pom.xml to manage junit version

## Testing
- [x] `testCommandExecutorRuntimeExceptionWithoutParams`
- [x] `testCommandExecutorRuntimeExceptionWithMessage`
- [x] `testCommandExecutorRuntimeExceptionWithCause`
- [x] `testCommandExecutorRuntimeExceptionWithCauseAndMessage`
- [x] `testCommandExecutorRuntimeExceptionWithAllParams`

## Checklist
- [x] My code follows the code style of this project
- [x]  I have run tests to ensure that my changes do not break existing code.
