### PR TITLE
Fixes issue #493 extract ascii art logic

### DIFF
--- a/cli/src/main/java/dev/buildcli/cli/CommandLineRunner.java
+++ b/cli/src/main/java/dev/buildcli/cli/CommandLineRunner.java
@@ -3,7 +3,6 @@ package dev.buildcli.cli;
 import dev.buildcli.cli.utils.BuildCLICommandMan;
 import dev.buildcli.core.domain.configs.BuildCLIConfig;
 import dev.buildcli.core.log.config.LoggingConfig;
-import dev.buildcli.core.utils.AsciiArtManager;
 import dev.buildcli.core.utils.BuildCLIService;
 import dev.buildcli.hooks.HookManager;
 import dev.buildcli.plugin.utils.BuildCLIPluginManager;
@@ -14,10 +13,7 @@ public class CommandLineRunner {
   public static void main(String[] args) {
     LoggingConfig.configure();
 
-    // Only display ASCII art welcome banner for specific commands
-    if (AsciiArtManager.shouldShowAsciiArt(args)) {
-      BuildCLIService.welcome();
-    }
+    BuildCLIService.welcome();
 
     BuildCLIConfig.initialize();
     var commandLine = new CommandLine(new BuildCLI());

--- a/cli/src/main/java/dev/buildcli/cli/CommandLineRunner.java
+++ b/cli/src/main/java/dev/buildcli/cli/CommandLineRunner.java
@@ -3,6 +3,7 @@ package dev.buildcli.cli;
 import dev.buildcli.cli.utils.BuildCLICommandMan;
 import dev.buildcli.core.domain.configs.BuildCLIConfig;
 import dev.buildcli.core.log.config.LoggingConfig;
+import dev.buildcli.core.utils.AsciiArtManager;
 import dev.buildcli.core.utils.BuildCLIService;
 import dev.buildcli.hooks.HookManager;
 import dev.buildcli.plugin.utils.BuildCLIPluginManager;
@@ -13,7 +14,10 @@ public class CommandLineRunner {
   public static void main(String[] args) {
     LoggingConfig.configure();
 
-    BuildCLIService.welcome();
+    // Only display ASCII art welcome banner for specific commands
+    if (AsciiArtManager.shouldShowAsciiArt(args)) {
+      BuildCLIService.welcome();
+    }
 
     BuildCLIConfig.initialize();
     var commandLine = new CommandLine(new BuildCLI());

--- a/cli/src/test/java/dev/buildcli/cli/core/BuildCLIServiceTest.java
+++ b/cli/src/test/java/dev/buildcli/cli/core/BuildCLIServiceTest.java
@@ -50,17 +50,6 @@ class BuildCLIServiceTest {
     }
   }
 
-  @Test
-  void testShouldShowAsciiArt() {
-    assertFalse(BuildCLIService.shouldShowAsciiArt(new String[]{}));
-    assertTrue(BuildCLIService.shouldShowAsciiArt(new String[]{"--help"}));
-    assertTrue(BuildCLIService.shouldShowAsciiArt(new String[]{"p", "run"}));
-    assertTrue(BuildCLIService.shouldShowAsciiArt(new String[]{"p", "i", "-n"}));
-    assertTrue(BuildCLIService.shouldShowAsciiArt(new String[]{"about"}));
-    assertTrue(BuildCLIService.shouldShowAsciiArt(new String[]{"help"}));
-    assertFalse(BuildCLIService.shouldShowAsciiArt(new String[]{"invalid"}));
-  }
-
   // TODO BuildCLIService need a refactor to improve testing capacity
   void checkUpdates_shouldShowOutdatedMessage_whenUpdateAvailable() {
     when(gitExecMock.checkIfLocalRepositoryIsUpdated(any(), eq(REPO_URL))).thenReturn(false);

--- a/core/src/main/java/dev/buildcli/core/utils/AsciiArtManager.java
+++ b/core/src/main/java/dev/buildcli/core/utils/AsciiArtManager.java
@@ -1,0 +1,56 @@
+package dev.buildcli.core.utils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class for managing the display of ASCII art in the BuildCLI.
+ * This class encapsulates the logic for determining when ASCII art should be shown.
+ */
+public class AsciiArtManager {
+
+    /**
+     * Determines whether ASCII art should be displayed based on the provided command line arguments.
+     *
+     * @param args Command line arguments
+     * @return true if ASCII art should be displayed, false otherwise
+     */
+    public static boolean shouldShowAsciiArt(String[] args) {
+        if (args.length == 0) {
+            return false;
+        }
+
+        if (Arrays.asList(args).contains("--help")) {
+            return true;
+        }
+
+        Map<String, List<String>> commandAliases = Map.of(
+                "p", List.of("p", "project"),
+                "about", List.of("a", "about"),
+                "help", List.of("help", "h")
+        );
+
+        String mainCommand = args[0];
+        if (matchesCommand(mainCommand, commandAliases.get("p"))) {
+            return args.length > 1 && (args[1].equals("run") || (args.length > 2 && args[1].equals("i") && args[2].equals("-n")));
+        }
+
+        if (matchesCommand(mainCommand, commandAliases.get("help"))) {
+            return true;
+        }
+
+        return matchesCommand(mainCommand, commandAliases.get("about"));
+    }
+
+    /**
+     * Checks if the input command matches any of the valid commands in the provided list.
+     *
+     * @param input Command to check
+     * @param validCommands List of valid commands
+     * @return true if the input matches any valid command, false otherwise
+     */
+    private static boolean matchesCommand(String input, List<String> validCommands) {
+        return validCommands != null && validCommands.contains(input);
+    }
+}

--- a/core/src/main/java/dev/buildcli/core/utils/AsciiArtManager.java
+++ b/core/src/main/java/dev/buildcli/core/utils/AsciiArtManager.java
@@ -4,18 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Utility class for managing the display of ASCII art in the BuildCLI.
- * This class encapsulates the logic for determining when ASCII art should be shown.
- */
 public class AsciiArtManager {
-
-    /**
-     * Determines whether ASCII art should be displayed based on the provided command line arguments.
-     *
-     * @param args Command line arguments
-     * @return true if ASCII art should be displayed, false otherwise
-     */
     public static boolean shouldShowAsciiArt(String[] args) {
         if (args.length == 0) {
             return false;
@@ -43,13 +32,6 @@ public class AsciiArtManager {
         return matchesCommand(mainCommand, commandAliases.get("about"));
     }
 
-    /**
-     * Checks if the input command matches any of the valid commands in the provided list.
-     *
-     * @param input Command to check
-     * @param validCommands List of valid commands
-     * @return true if the input matches any valid command, false otherwise
-     */
     private static boolean matchesCommand(String input, List<String> validCommands) {
         return validCommands != null && validCommands.contains(input);
     }

--- a/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
+++ b/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
@@ -75,6 +75,7 @@ public class BuildCLIService {
     System.out.println();
   }
 
+
   private static void updateBuildCLI() {
     if (updateRepository()) {
       generateBuildCLIJar();
@@ -134,10 +135,10 @@ public class BuildCLIService {
 
   private static String getFallbackDirectory() {
     String classLocation = BuildCLIService.class
-            .getProtectionDomain()
-            .getCodeSource()
-            .getLocation()
-            .toString();
+        .getProtectionDomain()
+        .getCodeSource()
+        .getLocation()
+        .toString();
     File location = new File(classLocation);
     return location.getAbsolutePath();
   }
@@ -157,4 +158,5 @@ public class BuildCLIService {
       throw new RuntimeException("Error while trying to read the content of the MANIFEST.MF file", e);
     }
   }
+
 }

--- a/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
+++ b/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
@@ -12,9 +12,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -78,37 +75,6 @@ public class BuildCLIService {
     System.out.println();
   }
 
-  public static boolean shouldShowAsciiArt(String[] args) {
-    if (args.length == 0) {
-      return false;
-    }
-
-    if (Arrays.asList(args).contains("--help")) {
-      return true;
-    }
-
-    Map<String, List<String>> commandAliases = Map.of(
-        "p", List.of("p", "project"),
-        "about", List.of("a", "about"),
-        "help", List.of("help", "h")
-    );
-
-    String mainCommand = args[0];
-    if (matchesCommand(mainCommand, commandAliases.get("p"))) {
-      return args.length > 1 && (args[1].equals("run") || (args.length > 2 && args[1].equals("i") && args[2].equals("-n")));
-    }
-
-    if (matchesCommand(mainCommand, commandAliases.get("help"))) {
-      return true;
-    }
-
-    return matchesCommand(mainCommand, commandAliases.get("about"));
-  }
-
-  private static boolean matchesCommand(String input, List<String> validCommands) {
-    return validCommands != null && validCommands.contains(input);
-  }
-
   private static void updateBuildCLI() {
     if (updateRepository()) {
       generateBuildCLIJar();
@@ -168,10 +134,10 @@ public class BuildCLIService {
 
   private static String getFallbackDirectory() {
     String classLocation = BuildCLIService.class
-        .getProtectionDomain()
-        .getCodeSource()
-        .getLocation()
-        .toString();
+            .getProtectionDomain()
+            .getCodeSource()
+            .getLocation()
+            .toString();
     File location = new File(classLocation);
     return location.getAbsolutePath();
   }
@@ -191,5 +157,4 @@ public class BuildCLIService {
       throw new RuntimeException("Error while trying to read the content of the MANIFEST.MF file", e);
     }
   }
-
 }

--- a/core/src/test/java/dev/buildcli/core/utils/AsciiArtManagerTest.java
+++ b/core/src/test/java/dev/buildcli/core/utils/AsciiArtManagerTest.java
@@ -1,59 +1,20 @@
 package dev.buildcli.core.utils;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AsciiArtManagerTest {
 
     @Test
-    void testEmptyArgs_shouldReturnFalse() {
-        // When args is empty
+    void testShouldShowAsciiArt() {
         assertFalse(AsciiArtManager.shouldShowAsciiArt(new String[]{}));
-    }
-
-    @Test
-    void testHelpFlag_shouldReturnTrue() {
-        // When args contains --help
         assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"--help"}));
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideProjectCommands")
-    void testProjectCommands(String[] args, boolean expected) {
-        assertEquals(expected, AsciiArtManager.shouldShowAsciiArt(args));
-    }
-
-    private static Stream<Arguments> provideProjectCommands() {
-        return Stream.of(
-                Arguments.of(new String[]{"p", "run"}, true),
-                Arguments.of(new String[]{"project", "run"}, true),
-                Arguments.of(new String[]{"p", "i", "-n"}, true),
-                Arguments.of(new String[]{"project", "i", "-n"}, true),
-                Arguments.of(new String[]{"p", "build"}, false),
-                Arguments.of(new String[]{"p", "i"}, false)
-        );
-    }
-
-    @Test
-    void testAboutCommand_shouldReturnTrue() {
+        assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"p", "run"}));
+        assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"p", "i", "-n"}));
         assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"about"}));
-        assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"a"}));
-    }
-
-    @Test
-    void testHelpCommand_shouldReturnTrue() {
         assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"help"}));
-        assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"h"}));
-    }
-
-    @Test
-    void testUnknownCommand_shouldReturnFalse() {
         assertFalse(AsciiArtManager.shouldShowAsciiArt(new String[]{"invalid"}));
     }
 }

--- a/core/src/test/java/dev/buildcli/core/utils/AsciiArtManagerTest.java
+++ b/core/src/test/java/dev/buildcli/core/utils/AsciiArtManagerTest.java
@@ -1,0 +1,59 @@
+package dev.buildcli.core.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AsciiArtManagerTest {
+
+    @Test
+    void testEmptyArgs_shouldReturnFalse() {
+        // When args is empty
+        assertFalse(AsciiArtManager.shouldShowAsciiArt(new String[]{}));
+    }
+
+    @Test
+    void testHelpFlag_shouldReturnTrue() {
+        // When args contains --help
+        assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"--help"}));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideProjectCommands")
+    void testProjectCommands(String[] args, boolean expected) {
+        assertEquals(expected, AsciiArtManager.shouldShowAsciiArt(args));
+    }
+
+    private static Stream<Arguments> provideProjectCommands() {
+        return Stream.of(
+                Arguments.of(new String[]{"p", "run"}, true),
+                Arguments.of(new String[]{"project", "run"}, true),
+                Arguments.of(new String[]{"p", "i", "-n"}, true),
+                Arguments.of(new String[]{"project", "i", "-n"}, true),
+                Arguments.of(new String[]{"p", "build"}, false),
+                Arguments.of(new String[]{"p", "i"}, false)
+        );
+    }
+
+    @Test
+    void testAboutCommand_shouldReturnTrue() {
+        assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"about"}));
+        assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"a"}));
+    }
+
+    @Test
+    void testHelpCommand_shouldReturnTrue() {
+        assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"help"}));
+        assertTrue(AsciiArtManager.shouldShowAsciiArt(new String[]{"h"}));
+    }
+
+    @Test
+    void testUnknownCommand_shouldReturnFalse() {
+        assertFalse(AsciiArtManager.shouldShowAsciiArt(new String[]{"invalid"}));
+    }
+}


### PR DESCRIPTION
Moved ASCIIArt logic into a separate class from BuildServiceCLI. Extracted ASCIIArt testing logic into a separate class. 