### PR TITLE
updated typo for example 3 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ buildcli project add profile dev
 Runs the Java project using Spring Boot:
 
 ```bash
-buildcli project run
+buildcli run
 ```
 
 ### 6. Generate Documentation for Java Code


### PR DESCRIPTION
Fixed command example from "buildcli project run" to "buildcli run"