### PR TITLE
Added Test Cases to ProjectUpdaterTest.java Issue #434

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ buildcli project add profile dev
 Runs the Java project using Spring Boot:
 
 ```bash
-buildcli project run
+buildcli run
 ```
 
 ### 6. Generate Documentation for Java Code

--- a/core/src/test/java/dev/buildcli/core/ProjectUpdaterTest.java
+++ b/core/src/test/java/dev/buildcli/core/ProjectUpdaterTest.java
@@ -2,58 +2,67 @@ package dev.buildcli.core;
 
 import dev.buildcli.core.project.ProjectUpdater;
 import dev.buildcli.core.utils.PomUtils;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ProjectUpdaterTest {
 
 	@TempDir
 	Path tempDir;
 
-	private static String backupPom;
-	private static String targetPom;
+	private String backupPom;
+	private String targetPom;
+	private String targetPomOriginalContent;
+	private String backupPomOriginalContent;
 	private ProjectUpdater updater;
 
 	@BeforeEach
 	void setUp() throws IOException {
 		this.updater = new ProjectUpdater();
 
-		InputStream originPomStream = getClass().getResourceAsStream("/pom-core-test/pom.xml");
+		// backup POM files
+		this.targetPom = "src/test/resources/pom-core-test/pom.xml";
+		this.backupPom = "src/test/resources/pom-core-test/pom.xml.versionsBackup";
 
-		Path tempPom = tempDir.resolve("pom.xml");
+		this.targetPomOriginalContent = Files.readString(Paths.get(this.targetPom));
+		this.backupPomOriginalContent = Files.readString(Paths.get(this.backupPom));
+	}
 
-		Files.copy(originPomStream, tempPom, StandardCopyOption.REPLACE_EXISTING);
-
-		targetPom = tempPom.toString();
-		backupPom = targetPom + ".versionsBackup";
-
+	@AfterEach
+	void restorePOMs() {
+		try{
+			Files.writeString(Paths.get(this.targetPom), this.targetPomOriginalContent);
+			Files.writeString(Paths.get(this.backupPom), this.backupPomOriginalContent);
+			Files.deleteIfExists(Paths.get("src/test/resources/pom-core-test/pom.xml.versionsBackup.versionsBackup"));
+		} catch(IOException e) {
+			e.printStackTrace();
+		}
+		
 	}
 
 	@Test
 	void shouldUpdatePomDependencies() {
-
-		targetPom = "src/test/resources/pom-core-test/pom.xml";
-		backupPom = "src/test/resources/pom-core-test/pom.xml.versionsBackup";
-
-		this.updater.setAdditionalParameters(List.of("-f", targetPom));
-		this.updater.updateNow(true).execute();
+		updater.setAdditionalParameters(List.of("-f", targetPom));
+		updater.updateNow(true).execute();
 
 		var originalPom = PomUtils.extractPomFile(backupPom);
 		var changedPom = PomUtils.extractPomFile(targetPom);
 
 		assertEquals(originalPom.countDependencies(), originalPom.getDependencies()
-						.stream().filter(changedPom::hasDependency).count());
+				.stream().filter(changedPom::hasDependency).count());
 		assertEquals(2, originalPom.getDependencies().stream()
 				.filter(d -> {
 					var xd = changedPom.getDependency(d);
@@ -63,4 +72,105 @@ class ProjectUpdaterTest {
 				.count());
 	}
 
+	@Test
+	void useOldDependencies() {
+		var originalPom = PomUtils.extractPomFile(backupPom);
+
+		updater.setAdditionalParameters(List.of("-f", backupPom));
+		updater.updateNow(false).execute();
+
+		var changedPom = PomUtils.extractPomFile(backupPom);
+
+		// checks if all dependencies are in "updated" pom
+		assertEquals(originalPom.countDependencies(), originalPom.getDependencies()
+				.stream().filter(changedPom::hasDependency).count());
+		// checks that all dependencies have the same version
+		assertEquals(3, originalPom.getDependencies().stream()
+				.filter(d -> {
+					var xd = changedPom.getDependency(d);
+					return (Objects.equals(d.getVersion(), xd.getVersion()));
+				})
+				.count());
+	}
+
+	@Test
+	void allDependenciesUpToDate() {
+		var originalPom = PomUtils.extractPomFile(targetPom);
+
+		updater.setAdditionalParameters(List.of("-f", targetPom));
+		updater.updateNow(true).execute();
+
+		var changedPom = PomUtils.extractPomFile(targetPom);
+
+		// checks if all dependencies are in "updated" pom
+		assertEquals(originalPom.countDependencies(), originalPom.getDependencies()
+				.stream().filter(changedPom::hasDependency).count());
+		// checks that all dependencies have the same version
+		assertEquals(3, originalPom.getDependencies().stream()
+				.filter(d -> {
+					var xd = changedPom.getDependency(d);
+					return (Objects.equals(d.getVersion(), xd.getVersion()));
+				})
+				.count());
+	}
+
+	@Test
+	void updateOutdatedDependencies() {
+		var originalPom = PomUtils.extractPomFile(backupPom);
+
+		updater.setAdditionalParameters(List.of("-f", backupPom));
+		updater.updateNow(true).execute();
+
+		var changedPom = PomUtils.extractPomFile(backupPom);
+
+		// checks if all dependencies are in "updated" pom
+		assertEquals(originalPom.countDependencies(), originalPom.getDependencies()
+				.stream().filter(changedPom::hasDependency).count());
+		// checks that 2 outdated dependencies updated
+		assertEquals(3, originalPom.getDependencies().stream()
+				.filter(d -> {
+					var xd = changedPom.getDependency(d);
+					return (d.getVersion() == null && xd.getVersion() == null) ||
+							(xd.getVersion().compareTo(d.getVersion()) >= 0);
+				})
+				.count());
+	}
+		
+	@Test
+	void emptyPOMFile() {
+		Path emptyPOM = tempDir.resolve("empty-pom.xml");
+		try {
+			Files.writeString(emptyPOM, "<project></project>");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		updater.setAdditionalParameters(List.of("-f", emptyPOM.toString()));
+		updater.updateNow(true).execute();
+
+		var updatedPom = PomUtils.extractPomFile(emptyPOM.toString());
+		assertEquals(0, updatedPom.countDependencies());
+	}
+	
+	@Test
+	void invalidPomFile() {
+		Path invalidPom = tempDir.resolve("invalid-pom.xml");
+		try {
+			Files.writeString(invalidPom, "<project><dependencies>");
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		updater.setAdditionalParameters(List.of("-f", invalidPom.toString()));
+
+		try {
+			updater.updateNow(true).execute();
+			fail("Expected exception for invalid pom");
+		} catch (Error e) {
+			// pass
+		}
+	}
 }
+
+
+


### PR DESCRIPTION
This is my first time contributing to open source. Here are the test cases I wrote

UseOldDependencies: Verifies that no updates are made when dependencies are outdated but isUpdateNow is set to false.
AllDependenciesUpToDate: Ensures no changes are made when all dependencies are already up to date.
UpdateOutdatedDependencies: Confirms that outdated dependencies are updated when isUpdateNow is true.
EmptyPomFile: Tests behavior when the pom.xml contains no dependencies.
InvalidPomFile: Validates that an error is thrown when an invalid pom.xml is provided.
