### PR TITLE
Test/docker build runner

### DIFF
--- a/core/src/main/java/dev/buildcli/core/utils/DockerBuildRunner.java
+++ b/core/src/main/java/dev/buildcli/core/utils/DockerBuildRunner.java
@@ -1,40 +1,35 @@
 package dev.buildcli.core.utils;
 
-import java.io.IOException;
+import dev.buildcli.core.actions.commandline.DockerProcess;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class DockerBuildRunner {
     private static final Logger logger = Logger.getLogger(DockerBuildRunner.class.getName());
+    private static final String IMAGE_TAG = "buildcli-app";
+
+    public DockerBuildRunner() {
+        // empty constructor for use in tests
+    }
 
     public void buildAndRunDocker() {
-        try {
-            // Executar o comando "docker build"
-            ProcessBuilder buildProcess = new ProcessBuilder(
-                    "docker", "build", "-t", "buildcli-app", "."
-            );
-            buildProcess.inheritIO();
-            int buildExitCode = buildProcess.start().waitFor();
-            if (buildExitCode != 0) {
-                logger.severe("Failed to build Docker image. Exit code: " + buildExitCode);
-                return;
-            }
-            System.out.println("Docker image built successfully.");
+        var buildProcess = DockerProcess.createBuildProcess(IMAGE_TAG);
+        int buildExitCode = buildProcess.run();
 
-            // Executar o comando "docker run"
-            ProcessBuilder runProcess = new ProcessBuilder(
-                    "docker", "run", "-p", "8080:8080", "buildcli-app"
-            );
-            runProcess.inheritIO();
-            int runExitCode = runProcess.start().waitFor();
-            if (runExitCode != 0) {
-                logger.severe("Failed to run Docker container. Exit code: " + runExitCode);
-            } else {
-                System.out.println("Docker container is running on port 8080.");
-            }
-        } catch (IOException | InterruptedException e) {
-            logger.log(Level.SEVERE, "Failed to build or run Docker container", e);
-            Thread.currentThread().interrupt();
+        if (buildExitCode != 0) {
+            logger.log(Level.INFO, "Failed with exit code: {}", buildExitCode);
+            return;
+        }
+        System.out.println("Docker image built successfully.");
+
+        var runProcess = DockerProcess.createRunProcess(IMAGE_TAG);
+        int runExitCode = runProcess.run();
+
+        if (runExitCode != 0) {
+            logger.log(Level.INFO, "Failed to run Docker container. Exit code: {}", runExitCode);
+        } else {
+            System.out.println("Docker container is running on port 8080.");
         }
     }
 }

--- a/core/src/test/java/dev/buildcli/core/utils/DockerBuildRunnerTest.java
+++ b/core/src/test/java/dev/buildcli/core/utils/DockerBuildRunnerTest.java
@@ -1,0 +1,102 @@
+package dev.buildcli.core.utils;
+
+import dev.buildcli.core.actions.commandline.DockerProcess;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DockerBuildRunnerTest {
+  @Test
+  void testBuildAndRunDocker_SuccessWithStaticMocks() {
+    DockerProcess buildMock = mock(DockerProcess.class);
+    DockerProcess runMock = mock(DockerProcess.class);
+
+    when(buildMock.run()).thenReturn(0);
+    when(runMock.run()).thenReturn(0);
+
+    try (MockedStatic<DockerProcess> dockerMockStatic = mockStatic(DockerProcess.class)) {
+      dockerMockStatic.when(() -> DockerProcess.createBuildProcess("buildcli-app"))
+          .thenReturn(buildMock);
+
+      dockerMockStatic.when(() -> DockerProcess.createRunProcess("buildcli-app"))
+          .thenReturn(runMock);
+
+      DockerBuildRunner runner = new DockerBuildRunner();
+      runner.buildAndRunDocker();
+
+      // Verificações
+      verify(buildMock).run();
+      verify(runMock).run();
+    }
+  }
+
+  @Test
+  void testBuildAndRunDocker_FailWithStaticMocks() {
+    DockerProcess buildMock = mock(DockerProcess.class);
+    DockerProcess runMock = mock(DockerProcess.class);
+
+    when(buildMock.run()).thenReturn(1);
+    when(runMock.run()).thenReturn(1);
+    try (
+        MockedStatic<DockerProcess> dockerMockStatic = mockStatic(DockerProcess.class)
+        ) {
+      dockerMockStatic.when(() -> DockerProcess.createBuildProcess("buildcli-app"))
+          .thenReturn(buildMock);
+
+      dockerMockStatic.when(() -> DockerProcess.createRunProcess("buildcli-app"))
+          .thenReturn(runMock);
+
+      DockerBuildRunner runner = new DockerBuildRunner();
+      runner.buildAndRunDocker();
+      verify(buildMock).run();
+      verifyNoInteractions(runMock);
+    }
+  }
+
+  @Test
+  void testBuildAndRunDocker_FailAtRunStep() throws IOException {
+
+    DockerProcess buildMock = mock(DockerProcess.class);
+    DockerProcess runMock = mock(DockerProcess.class);
+
+    when(buildMock.run()).thenReturn(0);
+    when(runMock.run()).thenReturn(1);
+
+    var outputStreamDefault = System.out;
+    try (
+        MockedStatic<DockerProcess> dockerMockStatic = mockStatic(DockerProcess.class);
+        ByteArrayOutputStream outContent = new ByteArrayOutputStream()
+    ) {
+      System.setOut(new PrintStream(outContent));
+      dockerMockStatic.when(() -> DockerProcess.createBuildProcess("buildcli-app"))
+          .thenReturn(buildMock);
+
+      dockerMockStatic.when(() -> DockerProcess.createRunProcess("buildcli-app"))
+          .thenReturn(runMock);
+
+      DockerBuildRunner runner = new DockerBuildRunner();
+      runner.buildAndRunDocker();
+
+      String output = outContent.toString();
+
+      assertEquals("Docker image built successfully.", output.trim());
+      verify(buildMock).run();
+      verify(runMock).run();
+
+    } finally {
+      System.setOut(outputStreamDefault);
+    }
+  }
+}
+


### PR DESCRIPTION
## Description
Refactored `DockerBuildRunner` to use `DockerProcess` and fixed logging format to avoid string concatenation. Added unit tests with static mocks for build and run steps.

## Related Issues
Unit Tests: DockerBuildRunner.java #423

## Changes
- Refactored `DockerBuildRunner` to use `DockerProcess.createBuildProcess`
- Added unit tests for success and failure cases

## Testing
- Used JUnit and Mockito static mocks
- Verified mock interactions and output


### Checklist
- [x] My code follows the code style of this project
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run tests to check that my changes do not break existing code

## Additional Notes
Suggestion: Refactor [`DockerfileCommand`](https://github.com/BuildCLI/BuildCLI/blob/main/cli/src/main/java/dev/buildcli/cli/commands/run/DockerfileCommand.java) to use the `DockerBuildAndRunner` class, so that we centralize the Docker logic, including build success verification, and eliminate redundant code.
