### PR TITLE
Unit Tests: ToolChecks.java

### DIFF
--- a/core/src/main/java/dev/buildcli/core/utils/tools/ToolChecks.java
+++ b/core/src/main/java/dev/buildcli/core/utils/tools/ToolChecks.java
@@ -1,43 +1,62 @@
 package dev.buildcli.core.utils.tools;
 
+import dev.buildcli.core.actions.commandline.GradleProcess;
+import dev.buildcli.core.actions.commandline.MavenProcess;
 import java.io.File;
-import java.io.IOException;
 
-import static dev.buildcli.core.utils.SystemCommands.GRADLE;
-import static dev.buildcli.core.utils.SystemCommands.MVN;
-
+/**
+ * Utility class for detecting and verifying Java build tools.
+ */
 public abstract class ToolChecks {
+
   private ToolChecks() {
   }
 
+  /**
+   * Verifies whether Maven is available and correctly configured by
+   * executing a version check command.
+   *
+   * @return {@code true} if Maven is available and responds correctly;
+   *         {@code false} if an error occurs or Maven is not found.
+   */
   public static boolean checksMaven() {
     try {
-      var process = new ProcessBuilder().command(MVN.getCommand(), "-v").start();
-
-      int exitCode = process.waitFor();
-
+      int exitCode = MavenProcess.createGetVersionProcessor().run();
       return exitCode == 0;
-    } catch (IOException | InterruptedException e) {
+    } catch (RuntimeException e) {
       return false;
     }
   }
 
+  /**
+   * Verifies whether Gradle is available and correctly configured by
+   * executing a version check command.
+   *
+   * @return {@code true} if Gradle is available and responds correctly;
+   *         {@code false} if an error occurs or Gradle is not found.
+   */
   public static boolean checksGradle() {
     try {
-      var process = new ProcessBuilder().command(GRADLE.getCommand(), "-v").start();
-
-      int exitCode = process.waitFor();
-
+      int exitCode = GradleProcess.createGetVersionProcess().run();
       return exitCode == 0;
-    } catch (IOException | InterruptedException e) {
+    } catch (RuntimeException e) {
       return false;
     }
   }
 
-  public static String checkIsMavenOrGradle(File directory) {
-     final boolean isMaven = new File(directory, "pom.xml").exists();
-     final boolean isGradle = new File(directory, "build.gradle").exists();
+  /**
+   * Determines whether the specified directory represents a Maven or
+   * Gradle project, based on the presence of standard build files.
+   *
+   * @param directory the project directory to analyze
+   * @return {@code "Maven"} if a {@code pom.xml} is found;
+   *         {@code "Gradle"} if a {@code build.gradle} is found;
+   *         {@code "Neither"} if none are found.
+   */
+  public static String checkIsMavenOrGradle(final File directory) {
+    final boolean isMaven = new File(directory, "pom.xml").exists();
+    final boolean isGradle = new File(directory, "build.gradle").exists();
 
-     return isMaven ? "Maven" : isGradle ? "Gradle": "Neither" ;
+    return isMaven ? "Maven" : isGradle ? "Gradle" : "Neither";
   }
 }

--- a/core/src/test/java/dev/buildcli/core/utils/tools/ToolChecksTest.java
+++ b/core/src/test/java/dev/buildcli/core/utils/tools/ToolChecksTest.java
@@ -1,0 +1,142 @@
+
+package dev.buildcli.core.utils.tools;
+
+import dev.buildcli.core.actions.commandline.GradleProcess;
+import dev.buildcli.core.actions.commandline.MavenProcess;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ToolChecksTest {
+
+  @TempDir
+  private Path tempDir;
+
+  @Test
+  void mavenCheckTrue() {
+    try (
+        MockedStatic<MavenProcess> mockedStatic = Mockito.mockStatic(MavenProcess.class)
+    ){
+      MavenProcess mockProcess = mock(MavenProcess.class);
+      when(mockProcess.run()).thenReturn(0);
+
+      mockedStatic.when(MavenProcess::createGetVersionProcessor).thenReturn(mockProcess);
+
+      var result = ToolChecks.checksMaven();
+      assertTrue(result);
+    }
+  }
+
+  @Test
+  void mavenCheckFalse() {
+    try (
+        MockedStatic<MavenProcess> mockedStatic = Mockito.mockStatic(MavenProcess.class)
+    ){
+      MavenProcess mockProcess = mock(MavenProcess.class);
+      when(mockProcess.run()).thenReturn(1);
+
+      mockedStatic.when(MavenProcess::createGetVersionProcessor).thenReturn(mockProcess);
+
+      var result = ToolChecks.checksMaven();
+      assertFalse(result);
+    }
+  }
+
+  @Test
+  void gradleCheck() {
+    try (
+        MockedStatic<GradleProcess> mockedStatic = Mockito.mockStatic(GradleProcess.class)
+    ){
+      GradleProcess mockProcess = mock(GradleProcess.class);
+      when(mockProcess.run()).thenReturn(0);
+
+      mockedStatic.when(GradleProcess::createGetVersionProcess).thenReturn(mockProcess);
+
+      var result = ToolChecks.checksGradle();
+      assertTrue(result);
+    }
+  }
+
+  @Test
+  void gradleCheckFalse() {
+    try (
+        MockedStatic<GradleProcess> mockedStatic = Mockito.mockStatic(GradleProcess.class)
+    ){
+      GradleProcess mockProcess = mock(GradleProcess.class);
+      when(mockProcess.run()).thenReturn(1);
+
+      mockedStatic.when(GradleProcess::createGetVersionProcess).thenReturn(mockProcess);
+
+      var result = ToolChecks.checksGradle();
+      assertFalse(result);
+    }
+  }
+
+  @Test
+  void gradleCheckRuntimeError() {
+    try (
+        MockedStatic<GradleProcess> mockedStatic = Mockito.mockStatic(GradleProcess.class)
+    ){
+      mockedStatic.when(GradleProcess::createGetVersionProcess)
+          .thenThrow(new RuntimeException("Error running Gradle process"));
+
+      boolean result = ToolChecks.checksGradle();
+      assertFalse(result);
+    }
+  }
+
+  @Test
+  void mavenCheckRuntimeError() {
+    try (
+        MockedStatic<MavenProcess> mockedStatic = Mockito.mockStatic(MavenProcess.class)
+    ){
+      mockedStatic.when(MavenProcess::createGetVersionProcessor)
+          .thenThrow(new RuntimeException("Error running Gradle process"));
+
+      boolean result = ToolChecks.checksMaven();
+      assertFalse(result);
+    }
+  }
+
+  @Test
+  void mavenIsMavenOrGradle_whenIsMaven() throws IOException {
+    String expected = "Maven";
+    createMockApplication(tempDir, "pom.xml");
+
+    String result = ToolChecks.checkIsMavenOrGradle(tempDir.toFile());
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void mavenIsMavenOrGradle_whenIsGradle() throws IOException {
+    String expected = "Gradle";
+    createMockApplication(tempDir, "build.gradle");
+
+    String result = ToolChecks.checkIsMavenOrGradle(tempDir.toFile());
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void mavenIsMavenOrGradle_whenIsNeither() throws IOException {
+    String expected = "Neither";
+    createMockApplication(tempDir, "someFile.txt");
+
+    String result = ToolChecks.checkIsMavenOrGradle(tempDir.toFile());
+    assertEquals(expected, result);
+  }
+
+  private void createMockApplication(Path rootDir, String nameFile) throws IOException {
+    Files.createFile(rootDir.resolve(nameFile));
+  }
+}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this PR -->

Refactored the `ToolChecks` utility class to detect and verify Java build tools (Maven and Gradle) using `MavenProcess` and `GradleProcess`.  
Added Javadoc comments for all public methods.  
Implemented unit tests for all utility methods in the `ToolChecks` class.

## Related Issues
<!-- Link any related issues or tasks. Use keywords to automatically close issues, e.g., Fixes #123 -->

Unit Tests: ToolChecks.java #399

## Changes
- Refactored `ToolChecks` to delegate tool verification to `MavenProcess` and `GradleProcess`
- Improved exception handling and method clarity
- Added Javadoc documentation for public methods
- Created `ToolChecksTest` with full coverage

## Testing
<!-- Describe how the changes were tested, and include any testing steps, screenshots, or other verification details -->
- Added unit tests for:
  - Successful Maven detection
  - Failed Maven detection
  - Successful Gradle detection
  - Failed Gradle detection
  - Runtime exceptions handling
  - Project type identification based on `pom.xml` or `build.gradle`

### Checklist
- [x] My code follows the code style of this project
- [x] I have added necessary documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run tests to check that my changes do not break existing code

## Additional Notes
<!-- Add any other relevant information or comments -->