### PR TITLE
test: add unit tests for NamespaceFilter

### DIFF
--- a/core/src/test/java/dev/buildcli/core/utils/NamespaceFilterTest.java
+++ b/core/src/test/java/dev/buildcli/core/utils/NamespaceFilterTest.java
@@ -1,0 +1,37 @@
+package dev.buildcli.core.utils;
+
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.XMLStreamReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NamespaceFilterTest {
+    @Test
+    public void testGetNamespaceURI() {
+        // Create a mock XMLStreamReader
+        XMLStreamReader reader = mock(XMLStreamReader.class);
+        when(reader.getNamespaceURI()).thenReturn("http://exemplo.com/ns");
+
+        // Create a NamespaceFilter
+        NamespaceFilter filter = new NamespaceFilter(reader);
+
+        // The overridden method must return an empty string
+        assertEquals("", filter.getNamespaceURI());
+    }
+
+    @Test
+    public void testGetAttributeNamespace() {
+        // Create a mock XMLStreamReader
+        XMLStreamReader reader = mock(XMLStreamReader.class);
+        when(reader.getAttributeNamespace(0)).thenReturn("http://exemplo.com/attr");
+
+        // Create a NamespaceFilter
+        NamespaceFilter filter = new NamespaceFilter(reader);
+
+        // The overridden method must return an empty string
+        assertEquals("", filter.getAttributeNamespace(0));
+    }
+}


### PR DESCRIPTION
This PR adds a new unit test class NamespaceFilterTest [(Issue 419)](https://github.com/BuildCLI/BuildCLI/issues/419) to validate the behavior of the NamespaceFilter utility.



Changes:

- Created NamespaceFilterTest under dev.buildcli.core.utils.
- Added test cases to verify that getAttributeNamespace and getNamespaceURI return empty strings as expected.
- Ensured tests run independently and follow existing testing standards in the project.
