### PR TITLE
Fixed bug of no root folder being created with given project name

### DIFF
--- a/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
@@ -54,7 +54,7 @@ public class InitCommand implements BuildCLICommand {
   }
 
   private void createReadme(String projectName, @Nullable Path rootDir) throws IOException {
-    File readme = new File(rootDir.toString(), "README.md");
+    File readme = rootDir == null ? new File("README.md") : new File(rootDir.toString(), "README.md");
     if (readme.createNewFile()) {
       try (FileWriter writer = new FileWriter(readme)) {
         writer.write("# " + projectName + "\n\nThis is the " + projectName + " project.");
@@ -64,7 +64,7 @@ public class InitCommand implements BuildCLICommand {
   }
 
   private void createMainClass(String basePackage, @Nullable Path rootDir) throws IOException {
-    String packagePath = (rootDir != null) ? rootDir.toString() + "src/main/java/" + basePackage.replace('.', '/') : "src/main/java/" + basePackage.replace('.', '/');
+    String packagePath = rootDir == null ? "src/main/java/" + basePackage.replace('.', '/') : rootDir.toString() + "src/main/java/" + basePackage.replace('.', '/');
     File packageDir = new File(packagePath);
     if (!packageDir.exists() && !packageDir.mkdirs()) {
       throw new IOException("Could not create package directory: " + packagePath);
@@ -87,8 +87,8 @@ public class InitCommand implements BuildCLICommand {
     }
   }
 
-  private void createPomFile(String projectName, String basePackage, @Nullable Path roothDir) throws IOException {
-    File pomFile = new File(roothDir.toString(), "pom.xml");
+  private void createPomFile(String projectName, String basePackage, @Nullable Path rootDir) throws IOException {
+    File pomFile = rootDir == null ? new File("pom.xml") : new File(rootDir.toString(), "pom.xml");
     if (pomFile.createNewFile()) {
       try (FileWriter writer = new FileWriter(pomFile)) {
         writer.write("""

--- a/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
@@ -12,7 +12,12 @@ import picocli.CommandLine.Option;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.LinkedList;
+
+import javax.annotation.Nullable;
 
 import static dev.buildcli.core.utils.console.input.InteractiveInputUtils.options;
 import static dev.buildcli.core.utils.console.input.InteractiveInputUtils.question;
@@ -48,8 +53,8 @@ public class InitCommand implements BuildCLICommand {
     }
   }
 
-  private void createReadme(String projectName) throws IOException {
-    File readme = new File("README.md");
+  private void createReadme(String projectName, @Nullable Path rootDir) throws IOException {
+    File readme = new File(rootDir.toString(), "README.md");
     if (readme.createNewFile()) {
       try (FileWriter writer = new FileWriter(readme)) {
         writer.write("# " + projectName + "\n\nThis is the " + projectName + " project.");
@@ -58,8 +63,8 @@ public class InitCommand implements BuildCLICommand {
     }
   }
 
-  private void createMainClass(String basePackage) throws IOException {
-    String packagePath = "src/main/java/" + basePackage.replace('.', '/');
+  private void createMainClass(String basePackage, @Nullable Path rootDir) throws IOException {
+    String packagePath = (rootDir != null) ? rootDir.toString() + "src/main/java/" + basePackage.replace('.', '/') : "src/main/java/" + basePackage.replace('.', '/');
     File packageDir = new File(packagePath);
     if (!packageDir.exists() && !packageDir.mkdirs()) {
       throw new IOException("Could not create package directory: " + packagePath);
@@ -82,8 +87,8 @@ public class InitCommand implements BuildCLICommand {
     }
   }
 
-  private void createPomFile(String projectName, String basePackage) throws IOException {
-    File pomFile = new File("pom.xml");
+  private void createPomFile(String projectName, String basePackage, @Nullable Path roothDir) throws IOException {
+    File pomFile = new File(roothDir.toString(), "pom.xml");
     if (pomFile.createNewFile()) {
       try (FileWriter writer = new FileWriter(pomFile)) {
         writer.write("""
@@ -143,13 +148,12 @@ public class InitCommand implements BuildCLICommand {
     }
   }
 
-  private void createRootDir(String projectName) throws IOException {
-    File rootDir = new File(projectName);
-    if (rootDir.mkdir()) {
-      SystemOutLogger.log("Root project directory " + projectName + " created successfully.");
-    } else {
-      SystemOutLogger.log("Failed to create root directory.");
-    }
+  private Path createRootDir(String projectName) throws IOException {
+    Path currentDir = Paths.get("").toAbsolutePath();
+    Path rootDir = currentDir.resolve(projectName);
+    Files.createDirectories(rootDir);
+    SystemOutLogger.log("Root directory created successfully.");
+    return rootDir;
   }
 
   private class QuickStartProject extends dev.buildcli.plugin.BuildCLITemplatePlugin {
@@ -178,10 +182,10 @@ public class InitCommand implements BuildCLICommand {
       }
 
       try {
-        createRootDir(projectName);
-        createReadme(projectName);
-        createMainClass(basePackage);
-        createPomFile(projectName, basePackage);
+        Path rootDir = createRootDir(projectName);
+        createReadme(projectName, rootDir);
+        createMainClass(basePackage, rootDir);
+        createPomFile(projectName, basePackage, rootDir);
       } catch (IOException e) {
         throw new CommandExecutorRuntimeException(e);
       }

--- a/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
@@ -64,7 +64,7 @@ public class InitCommand implements BuildCLICommand {
   }
 
   private void createMainClass(String basePackage, @Nullable Path rootDir) throws IOException {
-    String packagePath = rootDir == null ? "src/main/java/" + basePackage.replace('.', '/') : rootDir.toString() + "src/main/java/" + basePackage.replace('.', '/');
+    String packagePath = rootDir == null ? "src/main/java/" + basePackage.replace('.', '/') : rootDir.toString() + "/src/main/java/" + basePackage.replace('.', '/');
     File packageDir = new File(packagePath);
     if (!packageDir.exists() && !packageDir.mkdirs()) {
       throw new IOException("Could not create package directory: " + packagePath);
@@ -174,15 +174,16 @@ public class InitCommand implements BuildCLICommand {
           "src/test/java/" + basePackage.replace('.', '/')
       };
 
+      try {
+      Path rootDir = createRootDir(projectName);
+
       for (String dir : dirs) {
-        File directory = new File(dir);
+        File directory = new File(rootDir.toFile(), dir);
         if (directory.mkdirs()) {
           SystemOutLogger.log("Directory created: " + dir);
         }
       }
 
-      try {
-        Path rootDir = createRootDir(projectName);
         createReadme(projectName, rootDir);
         createMainClass(basePackage, rootDir);
         createPomFile(projectName, basePackage, rootDir);

--- a/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
+++ b/cli/src/main/java/dev/buildcli/cli/commands/project/InitCommand.java
@@ -143,6 +143,15 @@ public class InitCommand implements BuildCLICommand {
     }
   }
 
+  private void createRootDir(String projectName) throws IOException {
+    File rootDir = new File(projectName);
+    if (rootDir.mkdir()) {
+      SystemOutLogger.log("Root project directory " + projectName + " created successfully.");
+    } else {
+      SystemOutLogger.log("Failed to create root directory.");
+    }
+  }
+
   private class QuickStartProject extends dev.buildcli.plugin.BuildCLITemplatePlugin {
     @Override
     public TemplateType type() {
@@ -169,6 +178,7 @@ public class InitCommand implements BuildCLICommand {
       }
 
       try {
+        createRootDir(projectName);
         createReadme(projectName);
         createMainClass(basePackage);
         createPomFile(projectName, basePackage);

--- a/cli/src/test/java/dev/buildcli/cli/commands/project/InitCommandTest.java
+++ b/cli/src/test/java/dev/buildcli/cli/commands/project/InitCommandTest.java
@@ -2,22 +2,22 @@ package dev.buildcli.cli.commands.project;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import dev.buildcli.core.utils.console.input.InteractiveInputUtils;
 import picocli.CommandLine;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
 
 @DisplayName("InitCommand Tests")
-
 
 @ExtendWith({MockitoExtension.class})
 class InitCommandTest {
@@ -25,20 +25,31 @@ class InitCommandTest {
     @Test
     void executeCreatesCorrectly(@TempDir Path tempDir) throws IOException {
         
+        // Create mocks
+        MockedStatic<Paths> mockPaths = mockStatic(Paths.class);
+        MockedStatic<InteractiveInputUtils> mockInputUtils = mockStatic(InteractiveInputUtils.class);
+        mockPaths.when(() -> Paths.get("")).thenReturn(tempDir);
+        mockInputUtils.when(() -> InteractiveInputUtils.question("Enter base-package")).thenReturn("TestBasePackage");
+        
+
         // Setup
-        System.setProperty("user.dir", tempDir.toAbsolutePath().toString());
-        File expectedDir = new File(tempDir.toFile(), "TestRootDir");
-        String[] expectedFiles = { "pom.xml", "README.md", "Main.java" };
+        File expectedDir = tempDir.resolve("TestRootDir").toFile();
+        String[] expectedFiles = { "pom.xml", "README.md" };
+        String[] expectedDirs = { "src/main/java/TestBasePackage", "src/main/resources", "src/test/java/TestBasePackage" };
        
         // Run init
         InitCommand initCommand = new InitCommand();
-        new CommandLine(initCommand).execute("-n", "TestRootDir", "-j", "17", "-t", "false");
+        new CommandLine(initCommand).execute("-n", "TestRootDir", "-j", "17");
         
         // Assertions
         assertTrue(expectedDir.exists() && expectedDir.isDirectory());
         for (String FileName : expectedFiles) {
             File file = new File(expectedDir, FileName);
             assertTrue(file.exists() && file.isFile(), "File " + FileName + " was not created.");
+        }
+        for (String DirName : expectedDirs) {
+            File file = new File(DirName);
+            assertTrue(file.exists() && file.isDirectory(), "Directory " + DirName + " was not created");
         }
     }
 }

--- a/cli/src/test/java/dev/buildcli/cli/commands/project/InitCommandTest.java
+++ b/cli/src/test/java/dev/buildcli/cli/commands/project/InitCommandTest.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import dev.buildcli.cli.utilsfortest.LogbackExtension;
@@ -20,25 +21,20 @@ import static org.junit.jupiter.api.Assertions.*;
 @ExtendWith({MockitoExtension.class, LogbackExtension.class})
 class InitCommandTest {
 
+    @TempDir
     private File tempDir;
-    
-    @BeforeEach
-    void setup() throws Exception {
-        tempDir = Files.createTempDirectory("startDir").toFile();
-    }
-
-    @AfterEach
-    void tearDown() {
-        for (File file : tempDir.listFiles()) {
-            file.delete();
-        }
-        tempDir.delete();
-    }
+    private InitCommand initCommand;
 
     @Test
-    void executeCreatesCorrectly() {
-        String[] args = {"-n", "testDirName"};
-        int exitCode = new CommandLine(new GenerateCommand()).execute(args);
+    void executeCreatesCorrectly(@TempDir File tempDirFile) {
+        
+        tempDir = new File(tempDir, "StartDir");
+        initCommand = new InitCommand();
+        new CommandLine(initCommand).execute("-n", "TestRootDir", "-j", "17", "-t", "false");
+
+        
+        
+
     }
 
 }

--- a/cli/src/test/java/dev/buildcli/cli/commands/project/InitCommandTest.java
+++ b/cli/src/test/java/dev/buildcli/cli/commands/project/InitCommandTest.java
@@ -1,40 +1,44 @@
 package dev.buildcli.cli.commands.project;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import dev.buildcli.cli.utilsfortest.LogbackExtension;
-import dev.buildcli.cli.utilsfortest.LogbackLogger;
 import picocli.CommandLine;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("InitCommand Tests")
-@LogbackLogger(InitCommand.class)
 
 
-@ExtendWith({MockitoExtension.class, LogbackExtension.class})
+@ExtendWith({MockitoExtension.class})
 class InitCommandTest {
 
-    @TempDir
-    private File tempDir;
-    private InitCommand initCommand;
-
     @Test
-    void executeCreatesCorrectly(@TempDir File tempDirFile) {
+    void executeCreatesCorrectly(@TempDir Path tempDir) throws IOException {
         
-        tempDir = new File(tempDir, "StartDir");
-        initCommand = new InitCommand();
+        // Setup
+        System.setProperty("user.dir", tempDir.toAbsolutePath().toString());
+        File expectedDir = new File(tempDir.toFile(), "TestRootDir");
+        String[] expectedFiles = { "pom.xml", "README.md", "Main.java" };
+       
+        // Run init
+        InitCommand initCommand = new InitCommand();
         new CommandLine(initCommand).execute("-n", "TestRootDir", "-j", "17", "-t", "false");
-
         
-        
-
+        // Assertions
+        assertTrue(expectedDir.exists() && expectedDir.isDirectory());
+        for (String FileName : expectedFiles) {
+            File file = new File(expectedDir, FileName);
+            assertTrue(file.exists() && file.isFile(), "File " + FileName + " was not created.");
+        }
     }
-
 }

--- a/cli/src/test/java/dev/buildcli/cli/commands/project/InitCommandTest.java
+++ b/cli/src/test/java/dev/buildcli/cli/commands/project/InitCommandTest.java
@@ -1,0 +1,44 @@
+package dev.buildcli.cli.commands.project;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import dev.buildcli.cli.utilsfortest.LogbackExtension;
+import dev.buildcli.cli.utilsfortest.LogbackLogger;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("InitCommand Tests")
+@LogbackLogger(InitCommand.class)
+
+
+@ExtendWith({MockitoExtension.class, LogbackExtension.class})
+class InitCommandTest {
+
+    private File tempDir;
+    
+    @BeforeEach
+    void setup() throws Exception {
+        tempDir = Files.createTempDirectory("startDir").toFile();
+    }
+
+    @AfterEach
+    void tearDown() {
+        for (File file : tempDir.listFiles()) {
+            file.delete();
+        }
+        tempDir.delete();
+    }
+
+    @Test
+    void executeCreatesCorrectly() {
+        String[] args = {"-n", "testDirName"};
+        int exitCode = new CommandLine(new GenerateCommand()).execute(args);
+    }
+
+}


### PR DESCRIPTION
Updated the InitCommand class to create a root folder with the project name that is given, Created a test class to go along with this that passes