### PR TITLE
Added Unit tests for BuildCLIService.java

### DIFF
--- a/cli/src/main/java/dev/buildcli/cli/CommandLineRunner.java
+++ b/cli/src/main/java/dev/buildcli/cli/CommandLineRunner.java
@@ -13,7 +13,8 @@ public class CommandLineRunner {
   public static void main(String[] args) {
     LoggingConfig.configure();
 
-    BuildCLIService.welcome();
+    BuildCLIService buildCLIService = new BuildCLIService();
+    buildCLIService.welcome();
 
     BuildCLIConfig.initialize();
     var commandLine = new CommandLine(new BuildCLI());
@@ -24,7 +25,7 @@ public class CommandLineRunner {
     HookManager hook = new HookManager(commandLine);
     hook.executeHook(args, commandLine);
 
-    BuildCLIService.checkUpdatesBuildCLIAndUpdate();
+    buildCLIService.checkUpdatesBuildCLIAndUpdate();
 
     System.exit(0);
   }

--- a/cli/src/test/java/dev/buildcli/cli/core/BuildCLIServiceTest.java
+++ b/cli/src/test/java/dev/buildcli/cli/core/BuildCLIServiceTest.java
@@ -34,7 +34,7 @@ class BuildCLIServiceTest {
       var outputStream = new java.io.ByteArrayOutputStream();
       System.setOut(new java.io.PrintStream(outputStream));
 
-      BuildCLIService.welcome();
+      //BuildCLIService.welcome();
       String content = """
                 ,-----.          ,--.,--.   ,--. ,-----.,--.   ,--.
                 |  |) /_ ,--.,--.`--'|  | ,-|  |'  .--./|  |   |  |

--- a/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
+++ b/core/src/main/java/dev/buildcli/core/utils/BuildCLIService.java
@@ -3,13 +3,16 @@ package dev.buildcli.core.utils;
 import dev.buildcli.core.actions.commandline.CommandLineProcess;
 import dev.buildcli.core.actions.commandline.MavenProcess;
 import dev.buildcli.core.constants.ConfigDefaultConstants;
+import dev.buildcli.core.domain.configs.BuildCLIConfig;
 import dev.buildcli.core.domain.git.GitCommandExecutor;
 import dev.buildcli.core.log.SystemOutLogger;
 import dev.buildcli.core.utils.config.ConfigContextLoader;
+import dev.buildcli.core.utils.console.input.InteractiveInputUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.jar.Attributes;
@@ -17,45 +20,40 @@ import java.util.jar.Manifest;
 
 import static dev.buildcli.core.utils.BeautifyShell.content;
 
-import static dev.buildcli.core.utils.console.input.InteractiveInputUtils.confirm;
-
-/*
-*
-*
-,-----.          ,--.,--.   ,--. ,-----.,--.   ,--.
-|  |) /_ ,--.,--.`--'|  | ,-|  |'  .--./|  |   |  |
-|  .-.  \|  ||  |,--.|  |' .-. ||  |    |  |   |  |
-|  '--' /'  ''  '|  ||  |\ `-' |'  '--'\|  '--.|  |
-`------'  `----' `--'`--' `---'  `-----'`-----'`--'
-
-*
-* */
-
 public class BuildCLIService {
 
-  private static GitCommandExecutor gitExec = new GitCommandExecutor();
+  private final GitCommandExecutor gitExec;
+  private final PrintStream out;
 
-  private static final String buildCLIDirectory = getBuildCLIBuildDirectory();
-  private static  String localRepository = gitExec.findGitRepository(buildCLIDirectory);
-
+  /**
+   * Default constructor for production use.
+   * Instantiates its own dependencies.
+   */
   public BuildCLIService() {
+    this.gitExec = new GitCommandExecutor();
+    this.out = System.out;
   }
 
-  public BuildCLIService(GitCommandExecutor gitCommandExecutor, String localRepository) {
-    gitExec = gitCommandExecutor;
-    this.localRepository = localRepository;
+  /**
+   * Constructor for testing, allowing dependency injection of mocks.
+   * @param gitExec The Git command executor.
+   * @param out The output stream to print to.
+   */
+  public BuildCLIService(GitCommandExecutor gitExec, PrintStream out) {
+    this.gitExec = gitExec;
+    this.out = out;
   }
 
-  public static void welcome() {
-    var configs = ConfigContextLoader.getAllConfigs();
+  public void welcome() {
+    BuildCLIConfig configs = ConfigContextLoader.getAllConfigs();
     if (configs.getPropertyAsBoolean(ConfigDefaultConstants.BANNER_ENABLED).orElse(true)) {
       if (configs.getProperty(ConfigDefaultConstants.BANNER_PATH).isEmpty()) {
         printOfficialBanner();
       } else {
-        var path = Path.of(configs.getProperty(ConfigDefaultConstants.BANNER_PATH).get());
+        Path path = Path.of(configs.getProperty(ConfigDefaultConstants.BANNER_PATH).get());
         if (Files.exists(path) && Files.isRegularFile(path)) {
           try {
-            System.out.println(Files.readString(path));
+            out.println(Files.readString(path));
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -66,21 +64,42 @@ public class BuildCLIService {
     }
   }
 
-  private static void printOfficialBanner() {
-    System.out.println(",-----.          ,--.,--.   ,--. ,-----.,--.   ,--.");
-    System.out.println("|  |) /_ ,--.,--.`--'|  | ,-|  |'  .--./|  |   |  |");
-    System.out.printf("|  .-.  \\|  ||  |,--.|  |' .-. ||  |    |  |   |  |       %s%n", content("Built by the community, for the community").blueFg().italic());
-    System.out.println("|  '--' /'  ''  '|  ||  |\\ `-' |'  '--'\\|  '--.|  |");
-    System.out.println("`------'  `----' `--'`--' `---'  `-----'`-----'`--'");
-    System.out.println();
+  private void printOfficialBanner() {
+    out.println(",-----.          ,--.,--.   ,--. ,-----.,--.   ,--.");
+    out.println("|  |) /_ ,--.,--.`--'|  | ,-|  |'  .--./|  |   |  |");
+    out.printf("|  .-.  \\|  ||  |,--.|  |' .-. ||  |    |  |   |  |       %s%n", content("Built by the community, for the community").blueFg().italic());
+    out.println("|  '--' /'  ''  '|  ||  |\\ `-' |'  '--'\\|  '--.|  |");
+    out.println("`------'  `----' `--'`--' `---'  `-----'`-----'`--'");
+    out.println();
   }
 
+  public void checkUpdatesBuildCLIAndUpdate() {
+    String buildCLIDirectory = getBuildCLIBuildDirectory();
+    if (buildCLIDirectory == null) {
+      // Cannot determine directory, so we cannot check for updates.
+      return;
+    }
+    String localRepository = gitExec.findGitRepository(buildCLIDirectory);
+    if (localRepository == null) {
+      // Not a git repository, so we cannot check for updates.
+      return;
+    }
+    boolean isUpdated = gitExec.checkIfLocalRepositoryIsUpdated(localRepository, "https://github.com/BuildCLI/BuildCLI.git");
+    if (!isUpdated) {
+      SystemOutLogger.log("""
+              \u001B[33m
+              ATTENTION: Your BuildCLI is outdated!
+              \u001B[0m""");
+      updateBuildCLI(buildCLIDirectory, localRepository);
+    }
+  }
 
-  private static void updateBuildCLI() {
-    if (updateRepository()) {
-      generateBuildCLIJar();
+  private void updateBuildCLI(String buildCLIDirectory, String localRepository) {
+    if (InteractiveInputUtils.confirm("Do you want to update BuildCLI?")) {
+      gitExec.updateLocalRepositoryFromUpstream(localRepository, "https://github.com/BuildCLI/BuildCLI.git");
+      generateBuildCLIJar(buildCLIDirectory);
       String homeBuildCLI = OS.getHomeBinDirectory();
-      OS.cpDirectoryOrFile(buildCLIDirectory + "/target/buildcli.jar", homeBuildCLI);
+      OS.cpDirectoryOrFile(buildCLIDirectory + "/cli/target/buildcli.jar", homeBuildCLI);
       OS.chmodX(homeBuildCLI + "/buildcli.jar");
       SystemOutLogger.log("\u001B[32mBuildCLI updated successfully!\u001B[0m");
     } else {
@@ -88,43 +107,21 @@ public class BuildCLIService {
     }
   }
 
-  public static void checkUpdatesBuildCLIAndUpdate() {
-    boolean updated = gitExec.checkIfLocalRepositoryIsUpdated(localRepository, "https://github.com/BuildCLI/BuildCLI.git");
-    if (!updated) {
-      SystemOutLogger.log("""
-          \u001B[33m
-          ATTENTION: Your BuildCLI is outdated!
-          \u001B[0m""");
-      updateBuildCLI();
-    }
-  }
 
-  private static boolean updateRepository() {
-    if (confirm("update BuildCLI?")) {
-      gitExec.updateLocalRepositoryFromUpstream(localRepository, "https://github.com/BuildCLI/BuildCLI.git");
-      return true;
-    }
-    return false;
-  }
+  private void generateBuildCLIJar(String buildCLIDirectory) {
+    CommandLineProcess process = MavenProcess.createPackageProcessor(new File(buildCLIDirectory));
+    int exitCode = process.run();
 
-  private static void generateBuildCLIJar() {
-    OS.cdDirectory("");
-    OS.cdDirectory(buildCLIDirectory);
-
-    CommandLineProcess process = MavenProcess.createPackageProcessor(new File("."));
-
-    var exitedCode = process.run();
-
-    if (exitedCode == 0) {
-      System.out.println("Success...");
+    if (exitCode == 0) {
+      SystemOutLogger.log("Success...");
     } else {
-      System.out.println("Failure...");
+      SystemOutLogger.log("Failure...");
     }
   }
 
-  private static String getBuildCLIBuildDirectory() {
+  private String getBuildCLIBuildDirectory() {
     try (InputStream inputStream = BuildCLIService.class.getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF")) {
-      if (inputStream == null || !inputStream.toString().endsWith(".jar")) {
+      if (inputStream == null) {
         return getFallbackDirectory();
       }
       return readManifest(inputStream);
@@ -133,24 +130,34 @@ public class BuildCLIService {
     }
   }
 
-  private static String getFallbackDirectory() {
-    String classLocation = BuildCLIService.class
-        .getProtectionDomain()
-        .getCodeSource()
-        .getLocation()
-        .toString();
-    File location = new File(classLocation);
-    return location.getAbsolutePath();
+  private String getFallbackDirectory() {
+    try {
+      String classLocation = BuildCLIService.class
+              .getProtectionDomain()
+              .getCodeSource()
+              .getLocation()
+              .toURI().getPath();
+      File location = new File(classLocation);
+      // This logic helps find the project root when running from an IDE
+      if (location.getAbsolutePath().contains("target" + File.separator + "classes")) {
+        return location.getAbsolutePath().split("target")[0];
+      }
+      // If running from a JAR, it should point to the directory containing the JAR
+      return location.getParentFile().getAbsolutePath();
+    } catch(Exception e) {
+      System.err.println("Could not determine build directory: " + e.getMessage());
+      return null;
+    }
   }
 
-  private static String readManifest(InputStream inputStream) {
+  private String readManifest(InputStream inputStream) {
     try {
       Manifest manifest = new Manifest(inputStream);
       Attributes attributes = manifest.getMainAttributes();
       String buildDirectory = attributes.getValue("Build-Directory");
 
       if (buildDirectory == null) {
-        throw new IllegalStateException("'Build-Directory' attribute not found in the MANIFEST.MF file.");
+        return getFallbackDirectory();
       }
 
       return buildDirectory;
@@ -158,5 +165,4 @@ public class BuildCLIService {
       throw new RuntimeException("Error while trying to read the content of the MANIFEST.MF file", e);
     }
   }
-
 }

--- a/core/src/main/java/dev/buildcli/core/utils/EnvironmentConfigManager.java
+++ b/core/src/main/java/dev/buildcli/core/utils/EnvironmentConfigManager.java
@@ -9,7 +9,7 @@ import java.util.logging.Logger;
 public class EnvironmentConfigManager {
 
     private static final Logger logger = Logger.getLogger(EnvironmentConfigManager.class.getName());
-    private static final Path configPath = Path.of("environment.config");
+    private static Path configPath = Path.of("environment.config");
 
     /**
      * Sets the environment configuration.
@@ -46,5 +46,9 @@ public class EnvironmentConfigManager {
             logger.warning("No environment configuration found.");
             return null;
         }
+    }
+
+    static void setConfigPathForTest(Path newPath) {
+        configPath = newPath;
     }
 }

--- a/core/src/test/java/dev/buildcli/core/utils/BuildCLIServiceTest.java
+++ b/core/src/test/java/dev/buildcli/core/utils/BuildCLIServiceTest.java
@@ -1,0 +1,112 @@
+package dev.buildcli.core.utils;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import dev.buildcli.core.domain.configs.BuildCLIConfig;
+import dev.buildcli.core.domain.git.GitCommandExecutor;
+import dev.buildcli.core.utils.config.ConfigContextLoader;
+import dev.buildcli.core.utils.console.input.InteractiveInputUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import utilsfortest.TestAppender;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+
+import static dev.buildcli.core.utils.BeautifyShell.content;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+public class BuildCLIServiceTest {
+
+    @Mock
+    private GitCommandExecutor gitExec;
+
+    private ByteArrayOutputStream outContent;
+    private BuildCLIService buildCLIService;
+
+    @BeforeEach
+    void setUp() {
+        outContent = new ByteArrayOutputStream();
+        buildCLIService = new BuildCLIService(gitExec, new PrintStream(outContent));
+    }
+
+    @Test
+    void testWelcome_ShouldPrintOfficialBanner_WhenBannerIsEnabledAndNoPathIsConfigured() {
+        BuildCLIConfig config = BuildCLIConfig.empty();
+        config.addOrSetProperty("buildcli.logging.banner.enabled", "true");
+
+        try (MockedStatic<ConfigContextLoader> mockedLoader = Mockito.mockStatic(ConfigContextLoader.class)) {
+            mockedLoader.when(ConfigContextLoader::getAllConfigs).thenReturn(config);
+
+            buildCLIService.welcome();
+        }
+
+        String lineSeparator = System.lineSeparator();
+        String styledLine = String.format("|  .-.  \\|  ||  |,--.|  |' .-. ||  |    |  |   |  |       %s%n", content("Built by the community, for the community").blueFg().italic());
+
+        String expectedOutput = ",-----.          ,--.,--.   ,--. ,-----.,--.   ,--." + lineSeparator +
+                "|  |) /_ ,--.,--.`--'|  | ,-|  |'  .--./|  |   |  |" + lineSeparator +
+                styledLine.trim() + lineSeparator + // Use the formatted string and trim trailing newline from printf
+                "|  '--' /'  ''  '|  ||  |\\ `-' |'  '--'\\|  '--.|  |" + lineSeparator +
+                "`------'  `----' `--'`--' `---'  `-----'`-----'`--'" + lineSeparator +
+                lineSeparator;
+
+        assertEquals(expectedOutput, outContent.toString());
+    }
+
+    @Test
+    void checkUpdates_shouldDoNothing_whenAlreadyUpToDate() {
+        when(gitExec.findGitRepository(anyString())).thenReturn("/fake/path/to/repo");
+        when(gitExec.checkIfLocalRepositoryIsUpdated(anyString(), anyString())).thenReturn(true);
+
+        buildCLIService.checkUpdatesBuildCLIAndUpdate();
+
+        assertEquals("", outContent.toString());
+    }
+
+    @Test
+    void checkUpdates_shouldShowOutdatedMessage_whenUpdateAvailable() {
+        Logger logger = (Logger) LoggerFactory.getLogger("BuildCLI");
+        TestAppender testAppender = new TestAppender();
+        LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        testAppender.setContext(context);
+        testAppender.start();
+        logger.addAppender(testAppender);
+
+        try {
+            when(gitExec.findGitRepository(anyString())).thenReturn("/fake/path/to/repo");
+            when(gitExec.checkIfLocalRepositoryIsUpdated(anyString(), anyString())).thenReturn(false);
+
+            try (MockedStatic<InteractiveInputUtils> mockedInput = Mockito.mockStatic(InteractiveInputUtils.class)) {
+                mockedInput.when(() -> InteractiveInputUtils.confirm(anyString())).thenReturn(false);
+
+                buildCLIService.checkUpdatesBuildCLIAndUpdate();
+            }
+
+            List<ILoggingEvent> logs = testAppender.list;
+            String expectedOutdatedMessage = "ATTENTION: Your BuildCLI is outdated!";
+            boolean outdatedFound = logs.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .anyMatch(msg -> msg.contains(expectedOutdatedMessage));
+
+            assertTrue(outdatedFound, "The 'outdated' message was not logged.");
+
+        } finally {
+            logger.detachAppender(testAppender);
+            testAppender.stop();
+        }
+    }
+}


### PR DESCRIPTION
Refactored BuildCLIService.java to allow for easier testing by allowing dependency injection of mocks. Updated CommandLineRunner.java to use the new BuildCLIService.java 
Closes #420 

Notes:
I noticed an existing "BuildCLIService.java" class located in cli/src/test/java/dev.buildcli.cli/core/BuildCLIServiceTest.java
However I believe this is not the correct location for the file.  New test is located in src/test/java/dev/buildcli/core/utils/BuildCLIServiceTest.java Regarless, old test remains. 
