### PR TITLE
test: cover Dependency constructor

### DIFF
--- a/core/src/test/java/dev/buildcli/core/model/DependencyTest.java
+++ b/core/src/test/java/dev/buildcli/core/model/DependencyTest.java
@@ -19,6 +19,7 @@ public class DependencyTest {
 
   }
 
+  @Test
   void testConstructorWith3Args() {
     String groupId = "com.example";
     String artifactId = "my-lib";
@@ -73,5 +74,10 @@ public class DependencyTest {
     Assertions.assertEquals("war", dependency.getType());
     Assertions.assertEquals("test", dependency.getScope());
     Assertions.assertEquals("false", dependency.getOptional());
+  }
+
+  @Test
+  void testXmlWrapperElement() {
+    Assertions.assertEquals("dependencies", Dependency.XML_WRAPPER_ELEMENT);
   }
 }


### PR DESCRIPTION
## What changed

- Added the missing `@Test` annotation to `DependencyTest.testConstructorWith3Args()`.
- Added a focused assertion for `Dependency.XML_WRAPPER_ELEMENT`.

## Why

This completes the intended `Dependency` unit test coverage for issue #348 without changing production code.

Closes #348

## Verification

Because current `develop` has core build/test-compilation blockers addressed in PR #663, verification was run on the patched #663 baseline plus this one-file change:

- `JAVA_HOME=/Users/lucasmatricarde/Library/Java/JavaVirtualMachines/temurin-21.0.11/Contents/Home mvn -q -pl core -Dtest=DependencyTest test`
  - `DependencyTest` report: Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
- `JAVA_HOME=/Users/lucasmatricarde/Library/Java/JavaVirtualMachines/temurin-21.0.11/Contents/Home mvn -q -pl core -Dtest=ProjectUpdaterTest,PomUtilsTest,EnvironmentConfigManagerTest,DependencyTest test`

## Dependency note

This PR is intentionally a one-file diff against `develop` and should remain draft until #663 lands. Its current full CI failures are from the existing `develop` baseline, including workflow pinning and Maven POM/test-compilation blockers fixed in #663.
