### PR TITLE
test: cover pipeline generator factory

### DIFF
--- a/core/src/test/java/dev/buildcli/core/actions/pipeline/PipelineFileGeneratorFactoryTest.java
+++ b/core/src/test/java/dev/buildcli/core/actions/pipeline/PipelineFileGeneratorFactoryTest.java
@@ -1,0 +1,36 @@
+package dev.buildcli.core.actions.pipeline;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PipelineFileGeneratorFactoryTest {
+
+  @Test
+  void shouldReturnGithubActionsPipelineGenerator() {
+    PipelineFileGenerator generator = PipelineFileGenerator.PipelineFileGeneratorFactory.factory("github");
+
+    Assertions.assertInstanceOf(GithubActionsPipelineGenerator.class, generator);
+  }
+
+  @Test
+  void shouldReturnJenkinsPipelineGenerator() {
+    PipelineFileGenerator generator = PipelineFileGenerator.PipelineFileGeneratorFactory.factory("jenkins");
+
+    Assertions.assertInstanceOf(JenkinsPipelineGenerator.class, generator);
+  }
+
+  @Test
+  void shouldReturnGitlabPipelineGenerator() {
+    PipelineFileGenerator generator = PipelineFileGenerator.PipelineFileGeneratorFactory.factory("gitlab");
+
+    Assertions.assertInstanceOf(GitlabPipelineGenerator.class, generator);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenPlatformIsUnknown() {
+    IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
+        () -> PipelineFileGenerator.PipelineFileGeneratorFactory.factory("unknown"));
+
+    Assertions.assertEquals("Unexpected value: unknown", exception.getMessage());
+  }
+}


### PR DESCRIPTION
## What changed

- Added tests for `PipelineFileGenerator.PipelineFileGeneratorFactory.factory(...)`.
- Verified `github`, `jenkins`, and `gitlab` return the expected generator implementations.
- Verified an unknown platform throws `IllegalStateException`.

## Why

This adds focused factory coverage for issue #380 without exercising the file-writing behavior of the individual generators.

Closes #380

## Verification

Because current `develop` has core build/test-compilation blockers addressed in PR #663, verification was run on the patched #663 baseline plus this one-file change:

- `JAVA_HOME=/Users/lucasmatricarde/Library/Java/JavaVirtualMachines/temurin-21.0.11/Contents/Home mvn -q -pl core -Dtest=PipelineFileGeneratorFactoryTest test`
  - `PipelineFileGeneratorFactoryTest` report: Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
- `JAVA_HOME=/Users/lucasmatricarde/Library/Java/JavaVirtualMachines/temurin-21.0.11/Contents/Home mvn -q -pl core -Dtest=ProjectUpdaterTest,PomUtilsTest,EnvironmentConfigManagerTest,DependencyTest,PipelineFileGeneratorFactoryTest test`

## Dependency note

This PR is intentionally a one-file diff against `develop` and should remain draft until #663 lands. Its current full CI failures are from the existing `develop` baseline, including workflow pinning and Maven POM/test-compilation blockers fixed in #663.
