### PR TITLE
Add BeautifyShell unit tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -79,6 +79,11 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>5.12.2</version>
             <scope>test</scope>
@@ -122,6 +127,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
             </plugin>
         </plugins>
     </build>

--- a/core/src/main/java/dev/buildcli/core/utils/EnvironmentConfigManager.java
+++ b/core/src/main/java/dev/buildcli/core/utils/EnvironmentConfigManager.java
@@ -9,7 +9,11 @@ import java.util.logging.Logger;
 public class EnvironmentConfigManager {
 
     private static final Logger logger = Logger.getLogger(EnvironmentConfigManager.class.getName());
-    private static final Path configPath = Path.of("environment.config");
+    private static Path configPath = Path.of("environment.config");
+
+    static void setConfigPathForTest(Path path) {
+        configPath = path;
+    }
 
     /**
      * Sets the environment configuration.

--- a/core/src/test/java/dev/buildcli/core/utils/BeautifyShellTest.java
+++ b/core/src/test/java/dev/buildcli/core/utils/BeautifyShellTest.java
@@ -1,0 +1,261 @@
+package dev.buildcli.core.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class BeautifyShellTest {
+
+  private static final String RESET = "\u001B[0m";
+  private static final String BLACK_FG = "\u001B[30m";
+  private static final String RED_FG = "\u001B[31m";
+  private static final String GREEN_FG = "\u001B[32m";
+  private static final String YELLOW_FG = "\u001B[33m";
+  private static final String BLUE_FG = "\u001B[34m";
+  private static final String MAGENTA_FG = "\u001B[35m";
+  private static final String CYAN_FG = "\u001B[36m";
+  private static final String WHITE_FG = "\u001B[37m";
+  private static final String BRIGHT_BLACK_FG = "\u001B[90m";
+  private static final String BRIGHT_RED_FG = "\u001B[91m";
+  private static final String BRIGHT_GREEN_FG = "\u001B[92m";
+  private static final String BRIGHT_YELLOW_FG = "\u001B[93m";
+  private static final String BRIGHT_BLUE_FG = "\u001B[94m";
+  private static final String BRIGHT_MAGENTA_FG = "\u001B[95m";
+  private static final String BRIGHT_CYAN_FG = "\u001B[96m";
+  private static final String BRIGHT_WHITE_FG = "\u001B[97m";
+  private static final String BLACK_BG = "\u001B[40m";
+  private static final String RED_BG = "\u001B[41m";
+  private static final String GREEN_BG = "\u001B[42m";
+  private static final String YELLOW_BG = "\u001B[43m";
+  private static final String BLUE_BG = "\u001B[44m";
+  private static final String MAGENTA_BG = "\u001B[45m";
+  private static final String CYAN_BG = "\u001B[46m";
+  private static final String WHITE_BG = "\u001B[47m";
+  private static final String BRIGHT_BLACK_BG = "\u001B[100m";
+  private static final String BRIGHT_RED_BG = "\u001B[101m";
+  private static final String BRIGHT_GREEN_BG = "\u001B[102m";
+  private static final String BRIGHT_YELLOW_BG = "\u001B[103m";
+  private static final String BRIGHT_BLUE_BG = "\u001B[104m";
+  private static final String BRIGHT_MAGENTA_BG = "\u001B[105m";
+  private static final String BRIGHT_CYAN_BG = "\u001B[106m";
+  private static final String BRIGHT_WHITE_BG = "\u001B[107m";
+  private static final String BOLD = "\u001B[1m";
+  private static final String ITALIC = "\u001B[3m";
+  private static final String UNDERLINE = "\u001B[4m";
+  private static final String BLINK = "\u001B[5m";
+  private static final String REVERSE = "\u001B[7m";
+  private static final String STRIKETHROUGH = "\u001B[9m";
+  private static final String DOUBLE_UNDERLINE = "\u001B[21m";
+  private static final String FRAMED = "\u001B[51m";
+  private static final String ENCIRCLED = "\u001B[52m";
+  private static final String OVERLINED = "\u001B[53m";
+
+  @ParameterizedTest
+  @MethodSource("staticStyles")
+  void staticStyleMethodsWrapContentWithAnsiCode(Function<Object, String> style, String ansiCode) {
+    assertEquals(ansiCode + "BuildCLI" + RESET, style.apply("BuildCLI"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("staticStyles")
+  void staticStyleMethodsRenderNullContentAsString(Function<Object, String> style, String ansiCode) {
+    assertEquals(ansiCode + "null" + RESET, style.apply(null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("fluentStyles")
+  void fluentStyleMethodsPrefixContentWithAnsiCode(Function<BeautifyShell, BeautifyShell> style, String ansiCode) {
+    assertEquals(ansiCode + "BuildCLI" + RESET, style.apply(BeautifyShell.content("BuildCLI")).toString());
+  }
+
+  @Test
+  void contentCreatesFluentShellFromNonStringObject() {
+    assertEquals("123" + RESET, BeautifyShell.content(123).toString());
+  }
+
+  @Test
+  void contentThrowsNullPointerExceptionForNullContent() {
+    assertThrows(NullPointerException.class, () -> BeautifyShell.content(null));
+  }
+
+  @Test
+  void appendAddsPlainAndStyledContentInOrder() {
+    String result = BeautifyShell.content("Build")
+        .append("CLI")
+        .append("!", BeautifyShell::greenFg)
+        .toString();
+
+    assertEquals("BuildCLI" + GREEN_FG + "!" + RESET + RESET, result);
+  }
+
+  @Test
+  void appendThrowsNullPointerExceptionForNullContent() {
+    BeautifyShell shell = BeautifyShell.content("BuildCLI");
+
+    assertThrows(NullPointerException.class, () -> shell.append(null));
+  }
+
+  @Test
+  void chainedFluentStylesAreAppliedInReverseCallOrder() {
+    String result = BeautifyShell.content("BuildCLI")
+        .redFg()
+        .bold()
+        .underline()
+        .toString();
+
+    assertEquals(UNDERLINE + BOLD + RED_FG + "BuildCLI" + RESET, result);
+  }
+
+  @Test
+  void resetAddsResetCodesAroundExistingContentAndToStringAppendsAnotherReset() {
+    assertEquals(RESET + "BuildCLI" + RESET + RESET, BeautifyShell.content("BuildCLI").reset().toString());
+  }
+
+  @Test
+  void rainbowAppliesRepeatingForegroundColorsToEachCharacter() {
+    String expected = RED_FG + "B"
+        + YELLOW_FG + "u"
+        + GREEN_FG + "i"
+        + CYAN_FG + "l"
+        + BLUE_FG + "d"
+        + MAGENTA_FG + "C"
+        + RED_FG + "L"
+        + YELLOW_FG + "I"
+        + RESET;
+
+    assertEquals(expected, BeautifyShell.rainbow("BuildCLI"));
+  }
+
+  @Test
+  void fluentRainbowReplacesContentWithRainbowOutput() {
+    String expected = RED_FG + "C" + YELLOW_FG + "L" + GREEN_FG + "I" + RESET + RESET;
+
+    assertEquals(expected, BeautifyShell.content("CLI").rainbow().toString());
+  }
+
+  @Test
+  void gradientUsesStartColorForFirstHalfAndEndColorForSecondHalf() {
+    assertEquals(RED_FG + "B" + RED_FG + "u" + BLUE_FG + "i" + BLUE_FG + "l" + BLUE_FG + "d" + RESET,
+        BeautifyShell.gradient("Build", RED_FG, BLUE_FG));
+  }
+
+  @Test
+  void tableReturnsEmptyStringForNullOrEmptyInput() {
+    assertEquals("", BeautifyShell.table(null));
+    assertEquals("", BeautifyShell.table(List.of()));
+  }
+
+  @Test
+  void tableBuildsBorderedOutputUsingVisibleTextWidthAndPreservesStyledContent() {
+    String styledLine = BeautifyShell.redFg("warn");
+    String expected = "┌──────┐\n"
+        + BRIGHT_BLACK_FG + "│ " + RESET + "ok  " + BRIGHT_BLACK_FG + " │" + RESET + "\n"
+        + BRIGHT_BLACK_FG + "│ " + RESET + styledLine + BRIGHT_BLACK_FG + " │" + RESET + "\n"
+        + "└──────┘\n";
+
+    assertEquals(expected, BeautifyShell.table(List.of("ok", styledLine)));
+  }
+
+  private static Stream<Arguments> staticStyles() {
+    return Stream.of(
+        Arguments.of((Function<Object, String>) BeautifyShell::blackFg, BLACK_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::redFg, RED_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::greenFg, GREEN_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::yellowFg, YELLOW_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::blueFg, BLUE_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::magentaFg, MAGENTA_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::cyanFg, CYAN_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::whiteFg, WHITE_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightBlackFg, BRIGHT_BLACK_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightRedFg, BRIGHT_RED_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightGreenFg, BRIGHT_GREEN_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightYellowFg, BRIGHT_YELLOW_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightBlueFg, BRIGHT_BLUE_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightMagentaFg, BRIGHT_MAGENTA_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightCyanFg, BRIGHT_CYAN_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightWhiteFg, BRIGHT_WHITE_FG),
+        Arguments.of((Function<Object, String>) BeautifyShell::blackBg, BLACK_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::redBg, RED_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::greenBg, GREEN_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::yellowBg, YELLOW_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::blueBg, BLUE_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::magentaBg, MAGENTA_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::cyanBg, CYAN_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::whiteBg, WHITE_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightBlackBg, BRIGHT_BLACK_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightRedBg, BRIGHT_RED_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightGreenBg, BRIGHT_GREEN_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightYellowBg, BRIGHT_YELLOW_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightBlueBg, BRIGHT_BLUE_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightMagentaBg, BRIGHT_MAGENTA_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightCyanBg, BRIGHT_CYAN_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::brightWhiteBg, BRIGHT_WHITE_BG),
+        Arguments.of((Function<Object, String>) BeautifyShell::bold, BOLD),
+        Arguments.of((Function<Object, String>) BeautifyShell::italic, ITALIC),
+        Arguments.of((Function<Object, String>) BeautifyShell::underline, UNDERLINE),
+        Arguments.of((Function<Object, String>) BeautifyShell::blink, BLINK),
+        Arguments.of((Function<Object, String>) BeautifyShell::blinking, BLINK),
+        Arguments.of((Function<Object, String>) BeautifyShell::reverse, REVERSE),
+        Arguments.of((Function<Object, String>) BeautifyShell::strikethrough, STRIKETHROUGH),
+        Arguments.of((Function<Object, String>) BeautifyShell::doubleUnderline, DOUBLE_UNDERLINE),
+        Arguments.of((Function<Object, String>) BeautifyShell::framed, FRAMED),
+        Arguments.of((Function<Object, String>) BeautifyShell::encircled, ENCIRCLED),
+        Arguments.of((Function<Object, String>) BeautifyShell::overlined, OVERLINED)
+    );
+  }
+
+  private static Stream<Arguments> fluentStyles() {
+    return Stream.of(
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.blackFg(), BLACK_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.redFg(), RED_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.greenFg(), GREEN_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.yellowFg(), YELLOW_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.blueFg(), BLUE_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.magentaFg(), MAGENTA_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.cyanFg(), CYAN_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.whiteFg(), WHITE_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightBlackFg(), BRIGHT_BLACK_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightRedFg(), BRIGHT_RED_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightGreenFg(), BRIGHT_GREEN_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightYellowFg(), BRIGHT_YELLOW_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightBlueFg(), BRIGHT_BLUE_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightMagentaFg(), BRIGHT_MAGENTA_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightCyanFg(), BRIGHT_CYAN_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightWhiteFg(), BRIGHT_WHITE_FG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.blackBg(), BLACK_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.redBg(), RED_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.greenBg(), GREEN_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.yellowBg(), YELLOW_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.blueBg(), BLUE_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.magentaBg(), MAGENTA_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.cyanBg(), CYAN_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.whiteBg(), WHITE_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightBlackBg(), BRIGHT_BLACK_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightRedBg(), BRIGHT_RED_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightGreenBg(), BRIGHT_GREEN_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightYellowBg(), BRIGHT_YELLOW_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightBlueBg(), BRIGHT_BLUE_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightMagentaBg(), BRIGHT_MAGENTA_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightCyanBg(), BRIGHT_CYAN_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.brightWhiteBg(), BRIGHT_WHITE_BG),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.bold(), BOLD),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.italic(), ITALIC),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.underline(), UNDERLINE),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.blink(), BLINK),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.reverse(), REVERSE),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.strikethrough(), STRIKETHROUGH),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.doubleUnderline(), DOUBLE_UNDERLINE),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.framed(), FRAMED),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.encircled(), ENCIRCLED),
+        Arguments.of((Function<BeautifyShell, BeautifyShell>) shell -> shell.overlined(), OVERLINED)
+    );
+  }
+}


### PR DESCRIPTION
## Description

Adds unit coverage for `BeautifyShell` formatting behavior in the core module.

## Related Issues

Fixes #412

## Changes

- [x] Added comprehensive unit tests for static color/style helpers.
- [x] Added tests for fluent style methods, content mutation, append/reset behavior, rainbow/gradient output, and table formatting.
- [x] Enabled JUnit 5 test execution in the core module for the new test class.
- [x] Added a test-only configuration path hook required by existing tests.

## Testing

Validated locally with:

- `mvn -pl core -Dtest=BeautifyShellTest test`
- `mvn test`

Result:

- `BeautifyShellTest`: 139 tests run, 0 failures, 0 errors
- Full Maven suite: build success

### Checklist

- [x] My code follows the code style of this project.
- [x] I have added necessary documentation (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have run tests to check that my changes do not break existing code.

## Additional Notes

This draft PR is intentionally separate from the `develop` build fix in #667. It currently targets `main`, matching the branch used for the verified #412 work; it can be retargeted after maintainers confirm the preferred target branch.
